### PR TITLE
[#27] Adds akvoflow-dev2 to the list of dev instances

### DIFF
--- a/config/config.edn
+++ b/config/config.edn
@@ -23,7 +23,7 @@
  ;; List of instances to be excluded from the stats report
  :dev-instances ["akvoflowsandbox.appspot.com" "watermappingmonitoring-hrd.appspot.com"
                  "flowaglimmerofhope-hrd.appspot.com" "akvoflow-uat1.appspot.com"
-                 "akvoflow-dev1.appspot.com" "wfp-161.appspot.com"
+                 "akvoflow-dev1.appspot.com" "akvoflow-dev2.appspot.com" "wfp-161.appspot.com"
                  "flowdemoenvironment-hrd.appspot.com" "akvoflow-beta1.appspot.com"
                  "akvoflow-beta2.appspot.com"]
 }


### PR DESCRIPTION
Include `akvoflow-dev2` in to the list of dev instances
