### PR TITLE
[#58] Drop empty zip files from processing during bulk upload

### DIFF
--- a/src/akvo/flow_services/uploader.clj
+++ b/src/akvo/flow_services/uploader.clj
@@ -189,7 +189,8 @@
   [fcoll]
   (->> fcoll
     (remove #(.contains (.getAbsolutePath %) "__MACOSX"))
-    (remove #(.contains (.getName %) "wfpGenerated"))))
+    (remove #(.contains (.getName %) "wfpGenerated"))
+    (remove #(zero? (.length %)))))
 
 (defn get-format
   "Determine whether the zip file contains JSON or TSV data"


### PR DESCRIPTION
* Skip empty files and continue bulk upload