### PR TITLE
[#129] Convert survey-id parameter to Long

### DIFF
--- a/src/akvo/flow_services/uploader.clj
+++ b/src/akvo/flow_services/uploader.clj
@@ -125,7 +125,7 @@
                              :private-key-file (:private-key-file config)
                              :port 443}]
       (for [question (seq (query/result ds {:kind "Question"
-                                            :filter (query/= "surveyId" survey-id)
+                                            :filter (query/= "surveyId" (Long/valueOf survey-id))
                                             :keys-only true}))]
         (.getId (.getKey question))))))
 


### PR DESCRIPTION
Comparison using string value for the `survey-id` results in an error that the survey file uploaded does not match the one selected in the dashboard.  We use a long instead