### PR TITLE
[#168] Caddisfly test file url option

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/data.csv "0.1.3"]
                  [org.clojure/tools.nrepl "0.2.12"]
-                 [org.akvo/commons "0.4.0"]
+                 [org.akvo/commons "0.4.6"]
                  [com.taoensso/timbre "3.3.1"]
                  [cheshire "5.3.1"]
                  [compojure "1.1.8"]

--- a/src/akvo/flow_services/exporter.clj
+++ b/src/akvo/flow_services/exporter.clj
@@ -35,6 +35,11 @@
         bn (config/get-bucket-name base-url)]
     (format "%s/%s/%s/%s" base-path "reports" bn (UUID/randomUUID))))
 
+(defn- get-caddisfly-tests-file-url [options]
+  "Retrieve the URL for caddisfly tests file"
+  (let [bucket (get options "appId")]
+    (:caddisfly-tests-file-url (config/find-config bucket))))
+
 (defn- get-file [type base-url id]
   (let [path (get-path base-url)]
     (.mkdirs (io/file path))
@@ -48,7 +53,9 @@
         file (get-file type base-url id)
         options (assoc options
                        "maxDataReportRows"
-                       (:max-data-report-rows @config/settings))
+                       (:max-data-report-rows @config/settings)
+                       "caddisflyTestsFileUrl"
+                       (get-caddisfly-tests-file-url options))
         criteria (-> "uploadUrl"
                      options
                      config/get-bucket-name


### PR DESCRIPTION
With the change to akvo-commons v0.4.6 we are able to get the caddisfly test file URL which enables _optionally_ configuring a test file with specific tests for a single Flow instance.