### PR TITLE
[#181] NPE when generating COMPRENSIVE reports

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,9 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u162-jdk-stretch
 MAINTAINER Akvo Foundation <devops@akvo.org>
 
-RUN set -ex; apk update && \
-    apk add git openssh-client && \
-    rm -rf /var/cache/apk/*
+RUN set -ex; apt-get update && \
+    apt-get install git openssh-client && \
+    rm -rf /var/cache/apt/*
 
 WORKDIR /app
 COPY prod/start-prod-env.sh /app/start-prod-env.sh


### PR DESCRIPTION
awt classes missing in Alpine container, this causes all COMPRENSIVE reports to fail.
Changing container to stretch
Changing openjdk container to s