### PR TITLE
[#183] k8s restarts pod continously

### DIFF
--- a/ci/test/akvo-flow-services.yaml.template
+++ b/ci/test/akvo-flow-services.yaml.template
@@ -115,12 +115,12 @@ spec:
           httpGet:
             path: /healthz
             port: 3000
-          initialDelaySeconds: 30
+          initialDelaySeconds: 90
         readinessProbe:
           httpGet:
             path: /healthz
             port: 3000
-          initialDelaySeconds: 30
+          initialDelaySeconds: 90
 
 ---
 apiVersion: v1


### PR DESCRIPTION
As we checkout the flow-config repository on start, it can take a bit
of time to do it.

Delaying health checks to 90 secs