### PR TITLE
Remove Datatype from Option and Cascade responses

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8u162-jdk-stretch
 MAINTAINER Akvo Foundation <devops@akvo.org>
 
 RUN set -ex; apt-get update && \
-    apt-get install git openssh-client && \
+    apt-get install -y git openssh-client && \
     rm -rf /var/cache/apt/*
 
 WORKDIR /app

--- a/backend/project.clj
+++ b/backend/project.clj
@@ -50,4 +50,10 @@
                    :integration :integration
                    :kubernetes-test :kubernetes-test}
   :plugins [[lein-ring "0.8.5"]]
-  :profiles {:uberjar {:aot :all}})
+  :profiles {:dev  [:project/dev  :profiles/dev]
+             :test [:project/test :profiles/test]
+             :uberjar {:aot :all}
+             :profiles/dev  {}
+             :profiles/test {}
+             :project/dev   {:dependencies [[metosin/testit "0.2.0"]]}
+             :project/test  {}})

--- a/backend/src/akvo/flow_services/geoshape_export.clj
+++ b/backend/src/akvo/flow_services/geoshape_export.clj
@@ -19,10 +19,14 @@
             [akvo.commons.config :as config]
             [cheshire.core :as json]
             [taoensso.timbre :as timbre]
-            [akvo.flow-services.util :as util])
-  (:import [java.util UUID]))
+            [akvo.flow-services.util :as util]
+            [clojure.string :as s])
+  (:import [java.util UUID TimeZone]
+           (org.waterforpeople.mapping.dataexport.service BulkDataServiceClient)
+           (org.waterforpeople.mapping.dataexport ExportImportUtils)
+           (java.text SimpleDateFormat)))
 
-(defn feature [question-id questions question-answers]
+(defn feature [question-id questions question-answers instance-data]
   (let [geoshape (-> question-answers
                      (get question-id)
                      json/parse-string
@@ -30,45 +34,76 @@
                      first)]
     (when (and (= "Polygon" (get-in geoshape ["geometry" "type"]))
                (every? #(> (count %) 2) (get-in geoshape ["geometry" "coordinates"])))
-      (reduce (fn [feature [id value]]
-                (if (not= id question-id)
-                  (assoc-in feature ["properties" (get questions id)] value)
-                  feature))
-              geoshape
-              question-answers))))
+      (->
+        (reduce (fn [feature [id value]]
+                  (if (not= id question-id)
+                    (assoc-in feature ["properties" (get questions id)] value)
+                    feature))
+                geoshape
+                question-answers)
+        (update "properties" merge instance-data)))))
+
+(defn sanitize [s]
+  (or
+    (some-> s
+            (s/replace "\n" " ")
+            (s/replace "\t" "")
+            (s/trim))
+    ""))
+
+(defn duration-text [d]
+  (if d
+    (let [date-format (doto
+                        (SimpleDateFormat. "HH:mm:ss")
+                        (.setTimeZone (TimeZone/getTimeZone "GMT")))]
+      (try
+        (.format date-format (* 1000 d))
+        (catch Exception _ "")))
+    ""))
+
+(defn format-instance-data [instance-data]
+  (when instance-data
+    {"Identifier"        (:surveyedLocaleIdentifier instance-data)
+     "Display Name"      (:surveyedLocaleDisplayName instance-data)
+     "Device identifier" (:deviceIdentifier instance-data)
+     "Instance"          (str (:keyId instance-data))
+     "Submission Date"   (ExportImportUtils/formatDateTime (:collectionDate instance-data))
+     "Submitter"         (sanitize (:submitterName instance-data))
+     "Duration"          (duration-text (:surveyalTime instance-data))}))
 
 ;; question-id: the geoshape question id
 ;; quesions:    map from question id -> question text
 ;; responses:   map from instance-id -> question-id -> response text
-(defn build-features [question-id questions responses]
+;; instance-data: map from instance-id -> survey-instance-data
+(defn build-features [question-id questions responses instance-data]
   (for [[instance-id question-answers] responses]
-    (feature question-id questions question-answers)))
+    (feature question-id questions question-answers (format-instance-data (get instance-data instance-id)))))
 
-(defn build-feature-collection [form-id geoshape-question-id questions responses]
-  {:type "FeatureCollection"
-   :properties {:formId form-id
-                :questionId geoshape-question-id
+(defn build-feature-collection* [form-id geoshape-question-id questions responses instance-data]
+  {:type       "FeatureCollection"
+   :properties {:formId       form-id
+                :questionId   geoshape-question-id
                 :questionText (get questions geoshape-question-id)}
-   :features (remove nil? (build-features geoshape-question-id questions responses))})
+   :features   (remove nil? (build-features geoshape-question-id questions responses instance-data))})
 
 
 (defn fetch-responses [ds form-id]
   (let [responses (query/result ds
-                                {:kind "QuestionAnswerStore"
+                                {:kind   "QuestionAnswerStore"
                                  :filter (query/= "surveyId" form-id)}
                                 {:chunk-size 300})]
     (for [response responses]
-      {:value (or (.getProperty response "value")
-                  (.getValue (.getProperty response "valueText")))
-       :iteration (or (.getProperty response "iteration") 0)
+      {:value       (or (.getProperty response "value")
+                        (.getValue (.getProperty response "valueText")))
+       :iteration   (or (.getProperty response "iteration") 0)
        :instance-id (.getProperty response "surveyInstanceId")
        :question-id (Long/parseLong (.getProperty response "questionID"))})))
 
 (defn fetch-questions [ds form-id]
-  (let [questions (query/result ds {:kind "Question"
+  (let [questions (query/result ds {:kind   "Question"
                                     :filter (query/= "surveyId" form-id)})]
     (for [question questions]
-      {:id (-> question .getKey .getId)
+      {:id   (-> question .getKey .getId)
        :text (.getProperty question "text")})))
 
 (defn export-file [app-id form-id geoshape-question-id]
@@ -81,23 +116,44 @@
     (.mkdirs dir)
     (io/file dir filename)))
 
-(defn export [app-id form-id geoshape-question-id]
+(defn fetch-instance-data [server-base api-key instance-id]
+  (dissoc (bean (. (BulkDataServiceClient/fetchInstanceData instance-id server-base api-key) surveyInstanceData))
+          :class :approvedFlag :questionAnswersStore :surveyCode))
+
+(defn key-by [key-f val-f coll]
+  (reduce (fn [result x]
+            (assoc-in result (key-f x) (val-f x)))
+          {}
+          coll))
+
+(def key-questions (partial key-by (juxt :id) :text))
+(def key-responses (comp
+                     (partial key-by (juxt :instance-id :question-id) :value)
+                     (partial filter (comp zero? :iteration))))
+
+(def key-instance-data (partial key-by (juxt :keyId) identity))
+
+(defn build-feature-collection [form-id geoshape-question-id questions responses get-instance-data-fn]
+  (let [questions (key-questions questions)
+        responses (key-responses responses)
+        instance-datas (key-instance-data (get-instance-data-fn (keys responses)))]
+    (build-feature-collection* form-id
+                               geoshape-question-id
+                               questions
+                               responses
+                               instance-datas)))
+
+(defn export [baseUrl api-key app-id form-id geoshape-question-id]
   (timbre/infof "Exporting geoshape app-id: %s - form-id: %s - geoshape-question-id: %s" app-id form-id geoshape-question-id)
   (gae/with-datastore [ds (util/datastore-spec app-id)]
     (let [form-id (Long/parseLong form-id)
-          questions (reduce (fn [result {:keys [id text]}]
-                              (assoc result id text))
-                            {}
-                            (fetch-questions ds form-id))
-          responses (reduce (fn [result {:keys [instance-id question-id value]}]
-                              (assoc-in result [instance-id question-id] value))
-                            {}
-                            (filter #(zero? (:iteration %))
-                                    (fetch-responses ds form-id)))
-          feature-collection (build-feature-collection form-id
-                                                       geoshape-question-id
-                                                       questions
-                                                       responses)
+          questions (fetch-questions ds form-id)
+          responses (fetch-responses ds form-id)
+          instance-data-fn (fn [instance-ids]
+                             (map
+                               (partial fetch-instance-data baseUrl api-key)
+                               instance-ids))
+          feature-collection (build-feature-collection form-id geoshape-question-id questions responses instance-data-fn)
           file (export-file app-id form-id geoshape-question-id)]
       (with-open [writer (io/writer file)]
         (json/generate-stream feature-collection writer)

--- a/backend/src/akvo/flow_services/geoshape_export.clj
+++ b/backend/src/akvo/flow_services/geoshape_export.clj
@@ -26,6 +26,30 @@
            (org.waterforpeople.mapping.dataexport ExportImportUtils)
            (java.text SimpleDateFormat)))
 
+(defn parse-cascade-and-option
+  "Mostly translated from org.waterforpeople.mapping.dataexport.GraphicalSurveySummaryExporter.cascadeCellValues
+  and org.waterforpeople.mapping.dataexport.GraphicalSurveySummaryExporter.buildOptionString"
+  [value field]
+  (if (some-> value (s/starts-with? "["))
+    (try
+      (let [parsed-value (json/parse-string value true)]
+        (s/join "|" (map (fn [m]
+                           (let [field-value (get m field)
+                                 code (get m :code)]
+                             (cond
+                               (nil? code) field-value
+                               (= field-value code) field-value
+                               :else (str code ":" field-value))))
+                         parsed-value)))
+      (catch Exception _ value))
+    value))
+
+(defn parse-value [question value]
+  (case (:type question)
+    :CASCADE (parse-cascade-and-option value :name)
+    :OPTION (parse-cascade-and-option value :text)
+    value))
+
 (defn feature [question-id questions question-answers instance-data]
   (let [geoshape (-> question-answers
                      (get question-id)
@@ -37,7 +61,7 @@
       (->
         (reduce (fn [feature [id value]]
                   (if (not= id question-id)
-                    (assoc-in feature ["properties" (get questions id)] value)
+                    (assoc-in feature ["properties" (get questions id)] (parse-value (get questions id) value))
                     feature))
                 geoshape
                 question-answers)
@@ -104,6 +128,7 @@
                                     :filter (query/= "surveyId" form-id)})]
     (for [question questions]
       {:id   (-> question .getKey .getId)
+       :type (keyword (.getProperty question "type"))
        :text (.getProperty question "text")})))
 
 (defn export-file [app-id form-id geoshape-question-id]

--- a/backend/src/akvo/flow_services/scheduler.clj
+++ b/backend/src/akvo/flow_services/scheduler.clj
@@ -47,8 +47,11 @@
   (let [{:strs [baseURL exportType surveyId opts id]} (conversion/from-job-data job-data)
         questionId (get opts "questionId")
         appId (get opts "appId")
+        config (-> (get opts "uploadUrl")
+                config/get-bucket-name
+                (config/find-config))
         report (if (= exportType "GEOSHAPE")
-                 (geoshape/export appId surveyId questionId)
+                 (geoshape/export baseURL (:apiKey config) appId surveyId questionId)
                  (export-report exportType baseURL surveyId opts))
         path (get-path report)]
     (dosync

--- a/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
@@ -102,6 +102,7 @@
 
 (deftest report-generation
   (let [survey-id (System/currentTimeMillis)
+        survey-instance-id (rand-int 100000000)
         question-ids (gae/with-datastore [ds gae-local]
                        {:geo-question     (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "GeoQuestion"}))
                         :another-question (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "AnotherQuestion"}))})
@@ -111,13 +112,13 @@
                 [46.41390200704336 44.473117973161685]
                 [43.657240234315395 43.805380480517236]]]
     (gae/with-datastore [ds gae-local]
-      (doseq [answer [(question-answer survey-id 12233 (:geo-question question-ids)
+      (doseq [answer [(question-answer survey-id survey-instance-id (:geo-question question-ids)
                                        (json/generate-string {:features [{:type       "Feature",
                                                                           :properties some-additional-properties,
                                                                           :geometry   {:type        "Polygon",
                                                                                        :coordinates [coords]}}],
                                                               :type     "FeatureCollection"}))
-                      (question-answer survey-id 12233 (:another-question question-ids) "the other question response")]]
+                      (question-answer survey-id survey-instance-id (:another-question question-ids) "the other question response")]]
         (gae/put! ds "QuestionAnswerStore" answer)))
     (mock-gae survey-id)
     (mock-mailjet)

--- a/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
@@ -14,6 +14,8 @@
 (def wiremock-url "http://wiremock-proxy:8080")
 (def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
 (def flow-services-url "http://mainnetwork:3000")
+(def gae-local {:hostname "localhost"
+                :port     8888})
 
 (defn generate-report [survey-id question-id]
   (some->> (http/get (str flow-services-url "/generate")
@@ -91,32 +93,32 @@
                       (reset-wiremock)
                       (f)))
 
+(defn question-answer [survey-id survey-instance-id question-id value]
+  {"surveyId"         survey-id
+   "value"            value
+   "iteration"        0
+   "surveyInstanceId" survey-instance-id
+   "questionID"       (str question-id)})
+
 (deftest report-generation
   (let [survey-id (System/currentTimeMillis)
-        question-ids (gae/with-datastore [ds {:hostname "localhost"
-                                              :port     8888}]
-                       {:geo-question (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "GeoQuestion"}))
-                        :another-question (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "AnotherQuestion"}))})]
-    (gae/with-datastore [ds (util/datastore-spec "flowservices-dev-config")]
-      (gae/put! ds "QuestionAnswerStore"
-                {"surveyId"         survey-id
-                 "value"            (json/generate-string {:features [{:type       "Feature",
-                                                                       :properties {:length "598909.00", :pointCount "3", :area "13872516944.93"},
-                                                                       :geometry   {:type        "Polygon",
-                                                                                    :coordinates [[[43.657240234315395 43.805380480517236]
-                                                                                                   [44.38478909432889 42.843155681966564]
-                                                                                                   [46.41390200704336 44.473117973161685]
-                                                                                                   [43.657240234315395 43.805380480517236]]]}}],
-                                                           :type     "FeatureCollection"})
-                 "iteration"        0
-                 "surveyInstanceId" 1232133
-                 "questionID"       (str (:geo-question question-ids))})
-      (gae/put! ds "QuestionAnswerStore"
-                {"surveyId"         survey-id
-                 "value"            "the other question response"
-                 "iteration"        0
-                 "surveyInstanceId" 1232133
-                 "questionID"       (str (:another-question question-ids))}))
+        question-ids (gae/with-datastore [ds gae-local]
+                       {:geo-question     (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "GeoQuestion"}))
+                        :another-question (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "AnotherQuestion"}))})
+        some-additional-properties {:length "598909.00", :pointCount "3", :area "13872516944.93"}
+        coords [[43.657240234315395 43.805380480517236]
+                [44.38478909432889 42.843155681966564]
+                [46.41390200704336 44.473117973161685]
+                [43.657240234315395 43.805380480517236]]]
+    (gae/with-datastore [ds gae-local]
+      (doseq [answer [(question-answer survey-id 12233 (:geo-question question-ids)
+                                       (json/generate-string {:features [{:type       "Feature",
+                                                                          :properties some-additional-properties,
+                                                                          :geometry   {:type        "Polygon",
+                                                                                       :coordinates [coords]}}],
+                                                              :type     "FeatureCollection"}))
+                      (question-answer survey-id 12233 (:another-question question-ids) "the other question response")]]
+        (gae/put! ds "QuestionAnswerStore" answer)))
     (mock-gae survey-id)
     (mock-mailjet)
     (test-util/try-for "Processing for too long" 20
@@ -130,156 +132,9 @@
 
       (is (= 200 (:status (http/get (str flow-services-url "/report/" (get report-result "file"))))))
       (is (= {:type       "FeatureCollection",
-              :properties {:formId survey-id, :questionId (:geo-question question-ids), :questionText "GeoQuestion"},
+              :properties {:formId survey-id, :questionId (:geo-question question-ids), :questionText "GeoQuestion"}
               :features   [{:type       "Feature",
-                            :properties {:length "598909.00", :pointCount "3", :area "13872516944.93", :AnotherQuestion "the other question response"},
+                            :properties (assoc some-additional-properties :AnotherQuestion "the other question response")
                             :geometry   {:type        "Polygon",
-                                         :coordinates [[[43.657240234315395 43.805380480517236]
-                                                        [44.38478909432889 42.843155681966564]
-                                                        [46.41390200704336 44.473117973161685]
-                                                        [43.657240234315395 43.805380480517236]]]}}]}
-             (json/parse-string (:body (http/get (str flow-services-url "/report/" (get report-result "file")))) true)))
-      )))
-
-
-(comment
-
-  (http/get (str flow-services-url "/report/" "akvoflowsandbox/379db636-bdaf-46c5-805c-a0faf4cb23f3/GEOSHAPE-58863002-57103002.json"))
-
-
-  (cheshire.core/parse-string (slurp (akvo.flow-services.geoshape-export/export "akvoflowsandbox" "58863002" 57103002)) true)
-
-  (akvo.flow-services.geoshape-export/afffdf "flowservices-dev-config" "98765432")
-
-  (let [survey-id 987654322
-        question-ids (gae/with-datastore [ds {:hostname "localhost"
-                                              :port     8888}]
-                       {:area (.getId (gae/put! ds "Question" {"surveyId" survey-id
-                                                               "text"     "area"}))
-                        :name (.getId (gae/put! ds "Question" {"surveyId" survey-id
-                                                               "text"     "Name"}))})]
-    (println question-ids)
-    (gae/with-datastore [ds (util/datastore-spec "flowservices-dev-config")]
-      (gae/put! ds "QuestionAnswerStore"
-                {"surveyId"         survey-id
-                 "value"            (json/generate-string {:features [{:type       "Feature",
-                                                                       :properties {:length "598909.00", :pointCount "3", :area "13872516944.93"},
-                                                                       :geometry   {:type        "Polygon",
-                                                                                    :coordinates [[[43.657240234315395 43.805380480517236]
-                                                                                                   [44.38478909432889 42.843155681966564]
-                                                                                                   [46.41390200704336 44.473117973161685]
-                                                                                                   [43.657240234315395 43.805380480517236]]]}}],
-                                                           :type     "FeatureCollection"})
-                 "iteration"        0
-                 "surveyInstanceId" 1232133
-                 "questionID"       (str (:area question-ids))})
-      (gae/put! ds "QuestionAnswerStore"
-                {"surveyId"         survey-id
-                 "value"            "the name"
-                 "iteration"        0
-                 "surveyInstanceId" 1232133
-                 "questionID"       (str (:name question-ids))})))
-
-  (cheshire.core/parse-string (slurp (akvo.flow-services.geoshape-export/export "flowservices-dev-config" "987654322" 6333736731803648)) true)
-
-  (first *1)
-  (.getId *1)
-
-  (gae/with-datastore [ds (util/datastore-spec "flowservices-dev-config")]
-    (gae/put! ds "QuestionAnswerStore"
-              {"surveyId"         98765432
-               "value"            22
-               "iteration"        0
-               "surveyInstanceId" 1232133
-               "questionID"       "12321332"})
-    )
-
-
-
-  (def questions {50653003 "line",
-                  50673002 "Name",
-                  50683002 "number",
-                  53363002 "option",
-                  57093002 "location",
-                  57103002 "area",
-                  58873002 "point"})
-
-  (def responses
-    {57953002 {50653003 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"552675.25\",\"pointCount\":\"4\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[43.23931384831666,43.78561914089676],[44.20807980000973,42.921363044661035],[44.08121768385172,45.14443180309269],[45.61509657651187,43.935390171696014]]}}],\"type\":\"FeatureCollection\"}",
-               50673002 "vudhxhx",
-               50683002 "3",
-               53363002 "[{\"text\":\"hi\"}]",
-               57093002 "44.3853|44.9928|557|1kn16fhu0",
-               57103002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"598909.00\",\"pointCount\":\"3\",\"area\":\"13872516944.93\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[43.657240234315395,43.805380480517236],[44.38478909432889,42.843155681966564],[46.41390200704336,44.473117973161685],[43.657240234315395,43.805380480517236]]]}}],\"type\":\"FeatureCollection\"}",
-               58873002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"pointCount\":\"1\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[44.498739056289196,39.01059905333942]]}}],\"type\":\"FeatureCollection\"}"},
-     55203002 {50653003 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"1036760.50\",\"pointCount\":\"5\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[42.07189612090587,43.58658340603489],[42.62982007116079,45.83737041558021],[43.44724338501692,43.24709030496423],[43.706742748618126,45.19146079878792],[44.71879083663225,42.867645127003726]]}}],\"type\":\"FeatureCollection\"}",
-               50673002 "jfhxbx",
-               50683002 "2",
-               53363002 "[{\"text\":\"bye\"}]",
-               57093002 "44.3842|44.6855|586|1kmzcxqx3",
-               57103002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"758854.06\",\"pointCount\":\"6\",\"area\":\"38941915704.43\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[42.7153754979372,43.65410682496844],[42.31563717126846,45.01770027126581],[43.688070885837085,45.23405791922961],[45.4069447517395,44.4589416393743],[45.526865981519215,43.73122892181055],[44.48754720389842,43.23787603099734],[42.7153754979372,43.65410682496844]]]}}],\"type\":\"FeatureCollection\"}",
-               58873002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"pointCount\":\"1\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[43.841726928949356,44.20993576617068]]}}],\"type\":\"FeatureCollection\"}"},
-     55193002 {50653003 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"1337242.38\",\"pointCount\":\"7\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[44.29694976657629,44.40519672653736],[42.012350745499134,43.48753100574095],[40.53302228450776,48.21391293108405],[44.057304449379444,48.03955514592887],[45.13873390853405,47.00441785843146],[44.4252485409379,46.384848487787984],[43.1584482640028,46.46519301824055]]}}],\"type\":\"FeatureCollection\"}",
-               50673002 "zgxgx",
-               50683002 "1",
-               53363002 "[{\"text\":\"hi\"}]",
-               57093002 "44.6759|44.3829|1|1l0ds00mt",
-               57103002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"2347653.75\",\"pointCount\":\"4\",\"area\":\"328162525545.65\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[41.19146436452865,44.824926582495074],[45.881440602242954,50.17294952161225],[50.36297131329775,44.71387144987733],[45.516664534807205,42.023303031651594],[41.19146436452865,44.824926582495074]]]}}],\"type\":\"FeatureCollection\"}",
-               58873002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"pointCount\":\"3\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[43.823340721428394,44.00183494425441],[46.13008037209511,43.396263984482566],[44.956974014639854,43.16911421642557]]}}],\"type\":\"FeatureCollection\"}"}})
-
-  (def y (akvo.flow-services.geoshape-export/build-feature-collection nil 57103002 questions responses))
-  (akvo.flow-services.geoshape-export/build-features 57103002 questions responses)
-
-
-
-
-  (def xxx (org.waterforpeople.mapping.dataexport.service.BulkDataServiceClient/fetchInstanceData 57953002 "https://akvoflowsandbox.appspot.com" "nk34aR11m9"))
-
-
-  (bean (. xxx surveyInstanceData))
-
-  {"surveyedLocaleDisplayName" ""
-   "surveyId"                  survey-id
-   "surveyedLocaleId"          147442028
-   "userID"                    1
-   "collectionDate"            1418598306000
-   "submitterName"             "BASH & JAMES"
-   "deviceIdentifier"          "IMPORTER"
-   "surveyalTime"              0
-   "surveyedLocaleIdentifier"  "a6ey-5r1h-6a0y"
-   "keyId"                     instance-id}
-
-  {:surveyalTime              16,
-   :surveyCode                nil,
-   :collectionDate            #inst"2018-05-24T15:07:33.094-00:00",
-   :surveyedLocaleIdentifier  "381t-1vk2-2ph7",
-   :deviceIdentifier          "jana",
-   :surveyedLocaleDisplayName "vudhxhx - 3",
-   :submitterName             "jana",
-   :surveyId                  58863002,
-   :approvedFlag              nil,
-   :class                     org.waterforpeople.mapping.app.gwt.client.surveyinstance.SurveyInstanceDto,
-   :keyId                     57953002,
-   :userID                    1,
-   :surveyedLocaleId          56023002,
-   :questionAnswersStore      nil})
-
-;addMetaDataColumnHeader(IDENTIFIER_LABEL, ++columnIdx, row);
-;addMetaDataColumnHeader(DISPLAY_NAME_LABEL, ++columnIdx, row);
-;addMetaDataColumnHeader(DEVICE_IDENTIFIER_LABEL, ++columnIdx, row);
-;addMetaDataColumnHeader(INSTANCE_LABEL, ++columnIdx, row);
-;addMetaDataColumnHeader(SUB_DATE_LABEL, ++columnIdx, row);
-;addMetaDataColumnHeader(SUBMITTER_LABEL, ++columnIdx, row);
-;addMetaDataColumnHeader(DURATION_LABEL, ++columnIdx, row);
-
-
-;SurveyInstanceDto dto = instanceData.surveyInstanceDto;
-;int col = 0;
-;createCell(r, col++, dto.getSurveyedLocaleIdentifier());
-;createCell(r, col++, dto.getSurveyedLocaleDisplayName());
-;createCell(r, col++, dto.getDeviceIdentifier());
-;createCell(r, col++, dto.getKeyId().toString());
-;createCell(r, col++, ExportImportUtils.formatDateTime(dto.getCollectionDate()));
-;createCell(r, col++, sanitize(dto.getSubmitterName()));
-;String duration = getDurationText(dto.getSurveyalTime());
-;createCell(r, col++, duration);
+                                         :coordinates [coords]}}]}
+             (json/parse-string (:body (http/get (str flow-services-url "/report/" (get report-result "file")))) true))))))

--- a/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
@@ -4,7 +4,9 @@
             [cheshire.core :as json]
             [clj-http.client :as http]
             [akvo.flow-services.test-util :as test-util]
-            [akvo.commons.gae :as gae]))
+            [akvo.commons.gae :as gae]
+            [akvo.flow-services.core :as core]
+            [aero.core :as aero]))
 
 (def wiremock-url "http://wiremock-proxy:8080")
 (def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
@@ -83,6 +85,7 @@
   (test-util/wait-for-server "wiremock-proxy" 8080))
 
 (use-fixtures :once (fn [f]
+                      (core/config-logging (aero/read-config "dev/config.edn"))
                       (check-servers-up)
                       (reset-wiremock)
                       (f)))

--- a/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
@@ -10,7 +10,7 @@
 
 (def wiremock-url "http://wiremock-proxy:8080")
 (def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
-(def flow-services-url "http://mainnetwork:3000")
+(def flow-services-url "http://localhost:3000")
 (def gae-local {:hostname "localhost"
                 :port     8888})
 
@@ -81,7 +81,8 @@
   (http/post (str wiremock-mappings-url "/reset")))
 
 (defn check-servers-up []
-  (test-util/wait-for-server "mainnetwork" 3000)
+  (test-util/wait-for-server "localhost" 3000)
+  (test-util/wait-for-server "localhost" 8888)
   (test-util/wait-for-server "wiremock-proxy" 8080))
 
 (use-fixtures :once (fn [f]

--- a/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
@@ -1,0 +1,297 @@
+(ns akvo.flow-services.end-to-end-geoshape-test
+  {:integration true}
+  (:require [clojure.test :refer :all]
+            [cheshire.core :as json]
+            [clj-http.client :as http]
+            [akvo.flow-services.test-util :as test-util]
+            [akvo.flow-services.util :as util]
+            [akvo.commons.gae :as gae])
+  (:import java.util.Base64))
+
+(defn encode [to-encode]
+  (.encodeToString (Base64/getEncoder) (.getBytes to-encode)))
+
+(def wiremock-url "http://wiremock-proxy:8080")
+(def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
+(def flow-services-url "http://mainnetwork:3000")
+
+(defn generate-report [survey-id question-id]
+  (some->> (http/get (str flow-services-url "/generate")
+                     {:query-params {:callback "somejson"
+                                     :criteria (json/generate-string
+                                                 {"baseURL"    wiremock-url
+                                                  "exportType" "GEOSHAPE"
+                                                  "surveyId"   (str survey-id)
+                                                  "id"         "asdfxxxxx"
+                                                  "opts"       {"email"          "dan@akvo.org"
+                                                                "lastCollection" "false"
+                                                                "imgPrefix"      "https://akvoflowsandbox.s3.amazonaws.com/images/",
+                                                                "uploadUrl"      "https://akvoflowsandbox.s3.amazonaws.com/",
+                                                                "exportMode"     "GEOSHAPE"
+                                                                "questionId"     question-id
+                                                                "flowServices"   flow-services-url
+                                                                "appId"          "flowservices-dev-config"}})}})
+           :body
+           (re-seq #"somejson\((.*)\);")
+           first
+           second
+           json/parse-string))
+
+(defn survey-rest-api [action survey-id dto-list]
+  {"request"  {"method"          "GET"
+               "urlPath"         "/surveyrestapi"
+               "queryParameters" {"action"   {"equalTo" action}
+                                  "surveyId" {"equalTo" (str survey-id)}}}
+   "response" {"status"   200
+               "jsonBody" {"dtoList"     dto-list
+                           "resultCount" 0
+                           "offset"      0}}})
+
+(defn instance-data [survey-id instance-id]
+  {"request"  {"method"          "GET"
+               "urlPath"         "/instancedata"
+               "queryParameters" {"action"           {"equalTo" "getInstanceData"}
+                                  "surveyInstanceId" {"equalTo" (str instance-id)}}}
+   "response" {"status"   200
+               "jsonBody" {"surveyInstanceData"   {"surveyedLocaleDisplayName" ""
+                                                   "surveyId"                  survey-id
+                                                   "surveyedLocaleId"          147442028
+                                                   "userID"                    1
+                                                   "collectionDate"            1418598306000
+                                                   "submitterName"             "BASH & JAMES"
+                                                   "deviceIdentifier"          "IMPORTER"
+                                                   "surveyalTime"              0
+                                                   "surveyedLocaleIdentifier"  "a6ey-5r1h-6a0y"
+                                                   "keyId"                     instance-id}
+                           "latestApprovalStatus" ""
+                           "resultCount"          0
+                           "offset"               0}}})
+
+(defn mock-gae [survey-id]
+  (let [question-group-id 148442015
+        question-id 144672013
+        instance-id 144672047
+        messages [(instance-data survey-id instance-id)]]
+    (doseq [message messages]
+      (http/post wiremock-mappings-url {:body (json/generate-string message)}))))
+
+(defn mock-mailjet []
+  (http/post wiremock-mappings-url {:body (json/generate-string {"request"  {"method"  "POST"
+                                                                             "urlPath" "/mailjet/send"}
+                                                                 "response" {"status" 200
+                                                                             "body"   "ok"}})}))
+
+(defn email-sent-count [body]
+  (-> (http/post (str wiremock-url "/__admin/requests/count")
+                 {:as   :json
+                  :body (json/generate-string
+                          {"method"       "POST"
+                           "bodyPatterns" [{"matches" (str ".*" body ".*")}]
+                           "urlPath"      "/mailjet/send"})})
+      :body
+      :count))
+
+(defn reset-wiremock []
+  (http/post (str wiremock-mappings-url "/reset")))
+
+(defn check-servers-up []
+  (test-util/wait-for-server "mainnetwork" 3000)
+  (test-util/wait-for-server "wiremock-proxy" 8080))
+
+(use-fixtures :once (fn [f]
+                      (check-servers-up)
+                      (reset-wiremock)
+                      (f)))
+
+(deftest report-generation
+  (let [survey-id (System/currentTimeMillis)
+        question-ids (gae/with-datastore [ds {:hostname "localhost"
+                                              :port     8888}]
+                       {:area (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "area"}))
+                        :name (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "Name"}))})]
+    (gae/with-datastore [ds (util/datastore-spec "flowservices-dev-config")]
+      (gae/put! ds "QuestionAnswerStore"
+                {"surveyId"         survey-id
+                 "value"            (json/generate-string {:features [{:type       "Feature",
+                                                                       :properties {:length "598909.00", :pointCount "3", :area "13872516944.93"},
+                                                                       :geometry   {:type        "Polygon",
+                                                                                    :coordinates [[[43.657240234315395 43.805380480517236]
+                                                                                                   [44.38478909432889 42.843155681966564]
+                                                                                                   [46.41390200704336 44.473117973161685]
+                                                                                                   [43.657240234315395 43.805380480517236]]]}}],
+                                                           :type     "FeatureCollection"})
+                 "iteration"        0
+                 "surveyInstanceId" 1232133
+                 "questionID"       (str (:area question-ids))})
+      (gae/put! ds "QuestionAnswerStore"
+                {"surveyId"         survey-id
+                 "value"            "the name"
+                 "iteration"        0
+                 "surveyInstanceId" 1232133
+                 "questionID"       (str (:name question-ids))}))
+    (mock-gae survey-id)
+    (mock-mailjet)
+    (test-util/try-for "Processing for too long" 20
+                       (not= {"status" "OK", "message" "PROCESSING"}
+                             (generate-report survey-id (:area question-ids))))
+    (let [report-result (generate-report survey-id (:area question-ids))]
+      (is (= "OK" (get report-result "status")))
+
+      (test-util/try-for "email not sent" 5
+                         (= 1 (email-sent-count (get report-result "file"))))
+
+      (is (= 200 (:status (http/get (str flow-services-url "/report/" (get report-result "file"))))))
+      (is (= {:type "FeatureCollection",
+              :properties {:formId survey-id, :questionId (:area question-ids), :questionText "area"},
+              :features [{:type "Feature",
+                          :properties {:length "598909.00", :pointCount "3", :area "13872516944.93", :Name "the name"},
+                          :geometry {:type "Polygon",
+                                     :coordinates [[[43.657240234315395 43.805380480517236]
+                                                    [44.38478909432889 42.843155681966564]
+                                                    [46.41390200704336 44.473117973161685]
+                                                    [43.657240234315395 43.805380480517236]]]}}]}
+             (json/parse-string (:body (http/get (str flow-services-url "/report/" (get report-result "file")))) true)))
+      )))
+
+
+(comment
+
+  (http/get (str flow-services-url "/report/" "akvoflowsandbox/379db636-bdaf-46c5-805c-a0faf4cb23f3/GEOSHAPE-58863002-57103002.json"))
+
+
+  (cheshire.core/parse-string (slurp (akvo.flow-services.geoshape-export/export "akvoflowsandbox" "58863002" 57103002)) true)
+
+  (akvo.flow-services.geoshape-export/afffdf "flowservices-dev-config" "98765432")
+
+  (let [survey-id 987654322
+        question-ids (gae/with-datastore [ds {:hostname "localhost"
+                                              :port     8888}]
+                       {:area (.getId (gae/put! ds "Question" {"surveyId" survey-id
+                                                               "text"     "area"}))
+                        :name (.getId (gae/put! ds "Question" {"surveyId" survey-id
+                                                               "text"     "Name"}))})]
+    (println question-ids)
+    (gae/with-datastore [ds (util/datastore-spec "flowservices-dev-config")]
+      (gae/put! ds "QuestionAnswerStore"
+                {"surveyId"         survey-id
+                 "value"            (json/generate-string {:features [{:type       "Feature",
+                                                                       :properties {:length "598909.00", :pointCount "3", :area "13872516944.93"},
+                                                                       :geometry   {:type        "Polygon",
+                                                                                    :coordinates [[[43.657240234315395 43.805380480517236]
+                                                                                                   [44.38478909432889 42.843155681966564]
+                                                                                                   [46.41390200704336 44.473117973161685]
+                                                                                                   [43.657240234315395 43.805380480517236]]]}}],
+                                                           :type     "FeatureCollection"})
+                 "iteration"        0
+                 "surveyInstanceId" 1232133
+                 "questionID"       (str (:area question-ids))})
+      (gae/put! ds "QuestionAnswerStore"
+                {"surveyId"         survey-id
+                 "value"            "the name"
+                 "iteration"        0
+                 "surveyInstanceId" 1232133
+                 "questionID"       (str (:name question-ids))})))
+
+  (cheshire.core/parse-string (slurp (akvo.flow-services.geoshape-export/export "flowservices-dev-config" "987654322" 6333736731803648)) true)
+
+  (first *1)
+  (.getId *1)
+
+  (gae/with-datastore [ds (util/datastore-spec "flowservices-dev-config")]
+    (gae/put! ds "QuestionAnswerStore"
+              {"surveyId"         98765432
+               "value"            22
+               "iteration"        0
+               "surveyInstanceId" 1232133
+               "questionID"       "12321332"})
+    )
+
+
+
+  (def questions {50653003 "line",
+                  50673002 "Name",
+                  50683002 "number",
+                  53363002 "option",
+                  57093002 "location",
+                  57103002 "area",
+                  58873002 "point"})
+
+  (def responses
+    {57953002 {50653003 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"552675.25\",\"pointCount\":\"4\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[43.23931384831666,43.78561914089676],[44.20807980000973,42.921363044661035],[44.08121768385172,45.14443180309269],[45.61509657651187,43.935390171696014]]}}],\"type\":\"FeatureCollection\"}",
+               50673002 "vudhxhx",
+               50683002 "3",
+               53363002 "[{\"text\":\"hi\"}]",
+               57093002 "44.3853|44.9928|557|1kn16fhu0",
+               57103002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"598909.00\",\"pointCount\":\"3\",\"area\":\"13872516944.93\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[43.657240234315395,43.805380480517236],[44.38478909432889,42.843155681966564],[46.41390200704336,44.473117973161685],[43.657240234315395,43.805380480517236]]]}}],\"type\":\"FeatureCollection\"}",
+               58873002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"pointCount\":\"1\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[44.498739056289196,39.01059905333942]]}}],\"type\":\"FeatureCollection\"}"},
+     55203002 {50653003 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"1036760.50\",\"pointCount\":\"5\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[42.07189612090587,43.58658340603489],[42.62982007116079,45.83737041558021],[43.44724338501692,43.24709030496423],[43.706742748618126,45.19146079878792],[44.71879083663225,42.867645127003726]]}}],\"type\":\"FeatureCollection\"}",
+               50673002 "jfhxbx",
+               50683002 "2",
+               53363002 "[{\"text\":\"bye\"}]",
+               57093002 "44.3842|44.6855|586|1kmzcxqx3",
+               57103002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"758854.06\",\"pointCount\":\"6\",\"area\":\"38941915704.43\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[42.7153754979372,43.65410682496844],[42.31563717126846,45.01770027126581],[43.688070885837085,45.23405791922961],[45.4069447517395,44.4589416393743],[45.526865981519215,43.73122892181055],[44.48754720389842,43.23787603099734],[42.7153754979372,43.65410682496844]]]}}],\"type\":\"FeatureCollection\"}",
+               58873002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"pointCount\":\"1\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[43.841726928949356,44.20993576617068]]}}],\"type\":\"FeatureCollection\"}"},
+     55193002 {50653003 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"1337242.38\",\"pointCount\":\"7\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[44.29694976657629,44.40519672653736],[42.012350745499134,43.48753100574095],[40.53302228450776,48.21391293108405],[44.057304449379444,48.03955514592887],[45.13873390853405,47.00441785843146],[44.4252485409379,46.384848487787984],[43.1584482640028,46.46519301824055]]}}],\"type\":\"FeatureCollection\"}",
+               50673002 "zgxgx",
+               50683002 "1",
+               53363002 "[{\"text\":\"hi\"}]",
+               57093002 "44.6759|44.3829|1|1l0ds00mt",
+               57103002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"length\":\"2347653.75\",\"pointCount\":\"4\",\"area\":\"328162525545.65\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[41.19146436452865,44.824926582495074],[45.881440602242954,50.17294952161225],[50.36297131329775,44.71387144987733],[45.516664534807205,42.023303031651594],[41.19146436452865,44.824926582495074]]]}}],\"type\":\"FeatureCollection\"}",
+               58873002 "{\"features\":[{\"type\":\"Feature\",\"properties\":{\"pointCount\":\"3\"},\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[[43.823340721428394,44.00183494425441],[46.13008037209511,43.396263984482566],[44.956974014639854,43.16911421642557]]}}],\"type\":\"FeatureCollection\"}"}})
+
+  (def y (akvo.flow-services.geoshape-export/build-feature-collection nil 57103002 questions responses))
+  (akvo.flow-services.geoshape-export/build-features 57103002 questions responses)
+
+
+
+
+  (def xxx (org.waterforpeople.mapping.dataexport.service.BulkDataServiceClient/fetchInstanceData 57953002 "https://akvoflowsandbox.appspot.com" "nk34aR11m9"))
+
+
+  (bean (. xxx surveyInstanceData))
+
+  {"surveyedLocaleDisplayName" ""
+   "surveyId"                  survey-id
+   "surveyedLocaleId"          147442028
+   "userID"                    1
+   "collectionDate"            1418598306000
+   "submitterName"             "BASH & JAMES"
+   "deviceIdentifier"          "IMPORTER"
+   "surveyalTime"              0
+   "surveyedLocaleIdentifier"  "a6ey-5r1h-6a0y"
+   "keyId"                     instance-id}
+
+  {:surveyalTime              16,
+   :surveyCode                nil,
+   :collectionDate            #inst"2018-05-24T15:07:33.094-00:00",
+   :surveyedLocaleIdentifier  "381t-1vk2-2ph7",
+   :deviceIdentifier          "jana",
+   :surveyedLocaleDisplayName "vudhxhx - 3",
+   :submitterName             "jana",
+   :surveyId                  58863002,
+   :approvedFlag              nil,
+   :class                     org.waterforpeople.mapping.app.gwt.client.surveyinstance.SurveyInstanceDto,
+   :keyId                     57953002,
+   :userID                    1,
+   :surveyedLocaleId          56023002,
+   :questionAnswersStore      nil})
+
+;addMetaDataColumnHeader(IDENTIFIER_LABEL, ++columnIdx, row);
+;addMetaDataColumnHeader(DISPLAY_NAME_LABEL, ++columnIdx, row);
+;addMetaDataColumnHeader(DEVICE_IDENTIFIER_LABEL, ++columnIdx, row);
+;addMetaDataColumnHeader(INSTANCE_LABEL, ++columnIdx, row);
+;addMetaDataColumnHeader(SUB_DATE_LABEL, ++columnIdx, row);
+;addMetaDataColumnHeader(SUBMITTER_LABEL, ++columnIdx, row);
+;addMetaDataColumnHeader(DURATION_LABEL, ++columnIdx, row);
+
+
+;SurveyInstanceDto dto = instanceData.surveyInstanceDto;
+;int col = 0;
+;createCell(r, col++, dto.getSurveyedLocaleIdentifier());
+;createCell(r, col++, dto.getSurveyedLocaleDisplayName());
+;createCell(r, col++, dto.getDeviceIdentifier());
+;createCell(r, col++, dto.getKeyId().toString());
+;createCell(r, col++, ExportImportUtils.formatDateTime(dto.getCollectionDate()));
+;createCell(r, col++, sanitize(dto.getSubmitterName()));
+;String duration = getDurationText(dto.getSurveyalTime());
+;createCell(r, col++, duration);

--- a/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_geoshape_test.clj
@@ -4,21 +4,13 @@
             [cheshire.core :as json]
             [clj-http.client :as http]
             [akvo.flow-services.test-util :as test-util]
-            [akvo.commons.gae :as gae]
-            [akvo.flow-services.core :as core]
-            [aero.core :as aero]))
-
-(def wiremock-url "http://wiremock-proxy:8080")
-(def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
-(def flow-services-url "http://localhost:3000")
-(def gae-local {:hostname "localhost"
-                :port     8888})
+            [akvo.commons.gae :as gae]))
 
 (defn generate-report [survey-id question-id]
-  (some->> (http/get (str flow-services-url "/generate")
+  (some->> (http/get (str test-util/flow-services-url "/generate")
                      {:query-params {:callback "somejson"
                                      :criteria (json/generate-string
-                                                 {"baseURL"    wiremock-url
+                                                 {"baseURL"    test-util/wiremock-url
                                                   "exportType" "GEOSHAPE"
                                                   "surveyId"   (str survey-id)
                                                   "id"         "asdfxxxxx"
@@ -28,7 +20,7 @@
                                                                 "uploadUrl"      "https://akvoflowsandbox.s3.amazonaws.com/",
                                                                 "exportMode"     "GEOSHAPE"
                                                                 "questionId"     question-id
-                                                                "flowServices"   flow-services-url
+                                                                "flowServices"   test-util/flow-services-url
                                                                 "appId"          "flowservices-dev-config"}})}})
            :body
            (re-seq #"somejson\((.*)\);")
@@ -36,60 +28,10 @@
            second
            json/parse-string))
 
-(defn instance-data [survey-id instance-id]
-  {"request"  {"method"          "GET"
-               "urlPath"         "/instancedata"
-               "queryParameters" {"action"           {"equalTo" "getInstanceData"}
-                                  "surveyInstanceId" {"equalTo" (str instance-id)}}}
-   "response" {"status"   200
-               "jsonBody" {"surveyInstanceData"   {"surveyedLocaleDisplayName" "a survey display name"
-                                                   "surveyId"                  survey-id
-                                                   "surveyedLocaleId"          147442028
-                                                   "userID"                    1
-                                                   "collectionDate"            1418598306000
-                                                   "submitterName"             "BASH & JAMES"
-                                                   "deviceIdentifier"          "IMPORTER"
-                                                   "surveyalTime"              0
-                                                   "surveyedLocaleIdentifier"  "a6ey-5r1h-6a0y"
-                                                   "keyId"                     instance-id}
-                           "latestApprovalStatus" ""
-                           "resultCount"          0
-                           "offset"               0}}})
-
 (defn mock-gae [survey-id surveyed-instance-id]
-  (let [messages [(instance-data survey-id surveyed-instance-id)]]
-    (doseq [message messages]
-      (http/post wiremock-mappings-url {:body (json/generate-string message)}))))
+  (test-util/setup-wiremock [(test-util/instance-data survey-id surveyed-instance-id)]))
 
-(defn mock-mailjet []
-  (http/post wiremock-mappings-url {:body (json/generate-string {"request"  {"method"  "POST"
-                                                                             "urlPath" "/mailjet/send"}
-                                                                 "response" {"status" 200
-                                                                             "body"   "ok"}})}))
-
-(defn email-sent-count [body]
-  (-> (http/post (str wiremock-url "/__admin/requests/count")
-                 {:as   :json
-                  :body (json/generate-string
-                          {"method"       "POST"
-                           "bodyPatterns" [{"matches" (str ".*" body ".*")}]
-                           "urlPath"      "/mailjet/send"})})
-      :body
-      :count))
-
-(defn reset-wiremock []
-  (http/post (str wiremock-mappings-url "/reset")))
-
-(defn check-servers-up []
-  (test-util/wait-for-server "localhost" 3000)
-  (test-util/wait-for-server "localhost" 8888)
-  (test-util/wait-for-server "wiremock-proxy" 8080))
-
-(use-fixtures :once (fn [f]
-                      (core/config-logging (aero/read-config "dev/config.edn"))
-                      (check-servers-up)
-                      (reset-wiremock)
-                      (f)))
+(use-fixtures :once test-util/fixture)
 
 (defn question-answer [survey-id survey-instance-id question-id value]
   {"surveyId"         survey-id
@@ -101,7 +43,7 @@
 (deftest report-generation
   (let [survey-id (System/currentTimeMillis)
         survey-instance-id (rand-int 100000000)
-        question-ids (gae/with-datastore [ds gae-local]
+        question-ids (gae/with-datastore [ds test-util/gae-local]
                        {:geo-question     (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "GeoQuestion"}))
                         :another-question (.getId (gae/put! ds "Question" {"surveyId" survey-id "text" "AnotherQuestion"}))})
         some-additional-properties {:length "598909.00", :pointCount "3", :area "13872516944.93"}
@@ -109,7 +51,7 @@
                 [44.38478909432889 42.843155681966564]
                 [46.41390200704336 44.473117973161685]
                 [43.657240234315395 43.805380480517236]]]
-    (gae/with-datastore [ds gae-local]
+    (gae/with-datastore [ds test-util/gae-local]
       (doseq [answer [(question-answer survey-id survey-instance-id (:geo-question question-ids)
                                        (json/generate-string {:features [{:type       "Feature",
                                                                           :properties some-additional-properties,
@@ -119,7 +61,7 @@
                       (question-answer survey-id survey-instance-id (:another-question question-ids) "the other question response")]]
         (gae/put! ds "QuestionAnswerStore" answer)))
     (mock-gae survey-id survey-instance-id)
-    (mock-mailjet)
+    (test-util/mock-mailjet)
     (test-util/try-for "Processing for too long" 20
                        (not= {"status" "OK", "message" "PROCESSING"}
                              (generate-report survey-id (:geo-question question-ids))))
@@ -127,10 +69,10 @@
       (is (= "OK" (get report-result "status")))
 
       (test-util/try-for "email not sent" 5
-                         (= 1 (email-sent-count (get report-result "file"))))
+                         (= 1 (test-util/email-sent-count (get report-result "file"))))
 
-      (is (= 200 (:status (http/get (str flow-services-url "/report/" (get report-result "file"))))))
-      (let [report (json/parse-string (:body (http/get (str flow-services-url "/report/" (get report-result "file")))) true)]
+      (is (= 200 (:status (test-util/get-report report-result))))
+      (let [report (json/parse-string (:body (test-util/get-report report-result)) true)]
         (is (= coords (get-in report [:features 0 :geometry :coordinates 0])))
         (is (= "the other question response" (get-in report [:features 0 :properties :AnotherQuestion])))
         (is (= "BASH & JAMES" (get-in report [:features 0 :properties :Submitter])))))))

--- a/backend/test/akvo/flow_services/end_to_end_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_test.clj
@@ -11,7 +11,7 @@
 
 (def wiremock-url "http://wiremock-proxy:8080")
 (def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
-(def flow-services-url "http://mainnetwork:3000")
+(def flow-services-url "http://localhost:3000")
 
 (defn generate-report [survey-id]
   (some->> (http/get (str flow-services-url "/generate")

--- a/backend/test/akvo/flow_services/end_to_end_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_test.clj
@@ -3,7 +3,11 @@
   (:require [clojure.test :refer :all]
             [cheshire.core :as json]
             [clj-http.client :as http]
-            [akvo.flow-services.test-util :as test-util])
+            [akvo.flow-services.test-util :as test-util]
+            [akvo.flow-services.util :as util]
+            [akvo.commons.gae :as gae]
+            [aero.core :as aero]
+            [akvo.flow-services.core :as core])
   (:import java.util.Base64))
 
 (defn encode [to-encode]
@@ -202,8 +206,8 @@
   (-> (http/post (str wiremock-url "/__admin/requests/count")
                  {:as   :json
                   :body (json/generate-string
-                          {"method"       "POST"
-                           "urlPath"      "/sentry/api/213123/store/"})})
+                          {"method"  "POST"
+                           "urlPath" "/sentry/api/213123/store/"})})
       :body
       :count))
 
@@ -213,7 +217,7 @@
     (http/post wiremock-mappings-url {:body (json/generate-string {"request"  {"method"          "GET"
                                                                                "urlPath"         "/surveyrestapi"
                                                                                "queryParameters" {"surveyId" {"equalTo" (str survey-id)}}}
-                                                                   "response" {"status"   500}})})
+                                                                   "response" {"status" 500}})})
     (test-util/try-for "Processing for too long" 20
                        (= {"status" "ERROR", "message" "_error_generating_report"}
                           (generate-report survey-id)))

--- a/backend/test/akvo/flow_services/end_to_end_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_test.clj
@@ -3,25 +3,17 @@
   (:require [clojure.test :refer :all]
             [cheshire.core :as json]
             [clj-http.client :as http]
-            [akvo.flow-services.test-util :as test-util]
-            [akvo.flow-services.util :as util]
-            [akvo.commons.gae :as gae]
-            [aero.core :as aero]
-            [akvo.flow-services.core :as core])
+            [akvo.flow-services.test-util :as test-util])
   (:import java.util.Base64))
 
 (defn encode [to-encode]
   (.encodeToString (Base64/getEncoder) (.getBytes to-encode)))
 
-(def wiremock-url "http://wiremock-proxy:8080")
-(def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
-(def flow-services-url "http://localhost:3000")
-
 (defn generate-report [survey-id]
-  (some->> (http/get (str flow-services-url "/generate")
+  (some->> (http/get (str test-util/flow-services-url "/generate")
                      {:query-params {:callback "somejson"
                                      :criteria (json/generate-string
-                                                 {"baseURL"    wiremock-url
+                                                 {"baseURL"    test-util/wiremock-url
                                                   "exportType" "DATA_CLEANING"
                                                   "surveyId"   (str survey-id)
                                                   "id"         "asdf"
@@ -31,7 +23,7 @@
                                                                 "exportMode"     "DATA_CLEANING"
                                                                 "from"           "2013-03-06"
                                                                 "to"             "2018-03-09"
-                                                                "flowServices"   flow-services-url
+                                                                "flowServices"   test-util/flow-services-url
                                                                 "appId"          "flowservices-dev-config"}})}})
            :body
            (re-seq #"somejson\((.*)\);")
@@ -123,74 +115,25 @@
    "response" {"status" 200
                "body"   (str question-id ",0," (encode "https://akvoflow-14.s3.amazonaws.com/images/wfpPhoto8526862486761.jpg|Borehole|By The Chuch|AfriDev") "\n")}})
 
-(defn instance-data [survey-id instance-id]
-  {"request"  {"method"          "GET"
-               "urlPath"         "/instancedata"
-               "queryParameters" {"action"           {"equalTo" "getInstanceData"}
-                                  "surveyInstanceId" {"equalTo" (str instance-id)}}}
-   "response" {"status"   200
-               "jsonBody" {"surveyInstanceData"   {"surveyedLocaleDisplayName" ""
-                                                   "surveyId"                  survey-id
-                                                   "surveyedLocaleId"          147442028
-                                                   "userID"                    1
-                                                   "collectionDate"            1418598306000
-                                                   "submitterName"             "BASH & JAMES"
-                                                   "deviceIdentifier"          "IMPORTER"
-                                                   "surveyalTime"              0
-                                                   "surveyedLocaleIdentifier"  "a6ey-5r1h-6a0y"
-                                                   "keyId"                     instance-id}
-                           "latestApprovalStatus" ""
-                           "resultCount"          0
-                           "offset"               0}}})
-
 (defn mock-gae [survey-id]
   (let [question-group-id 148442015
         question-id 144672013
-        instance-id 144672047
-        messages [(gae-survey-group survey-id)
-                  (gae-list-survey-questions survey-id question-group-id question-id)
-                  (survey-rest-api "listSurveyQuestionOptions" survey-id [])
-                  (gae-list-groups survey-id question-group-id)
+        instance-id 144672047]
+    (test-util/setup-wiremock [(gae-survey-group survey-id)
+                               (gae-list-survey-questions survey-id question-group-id question-id)
+                               (survey-rest-api "listSurveyQuestionOptions" survey-id [])
+                               (gae-list-groups survey-id question-group-id)
 
-                  (gae-list-instances survey-id instance-id)
-                  (instance-responses instance-id question-id)
-                  (instance-data survey-id instance-id)]]
-    (doseq [message messages]
-      (http/post wiremock-mappings-url {:body (json/generate-string message)}))))
+                               (gae-list-instances survey-id instance-id)
+                               (instance-responses instance-id question-id)
+                               (test-util/instance-data survey-id instance-id)])))
 
-(defn mock-mailjet []
-  (http/post wiremock-mappings-url {:body (json/generate-string {"request"  {"method"  "POST"
-                                                                             "urlPath" "/mailjet/send"}
-                                                                 "response" {"status" 200
-                                                                             "body"   "ok"}})}))
-
-(defn email-sent-count [body]
-  (-> (http/post (str wiremock-url "/__admin/requests/count")
-                 {:as   :json
-                  :body (json/generate-string
-                          {"method"       "POST"
-                           "bodyPatterns" [{"matches" (str ".*" body ".*")}]
-                           "urlPath"      "/mailjet/send"})})
-      :body
-      :count))
-
-(defn reset-wiremock []
-  (http/post (str wiremock-mappings-url "/reset")))
-
-(defn check-servers-up []
-  (test-util/wait-for-server "mainnetwork" 3000)
-  (test-util/wait-for-server "wiremock-proxy" 8080))
-
-(use-fixtures :once (fn [f]
-                      (core/config-logging (aero/read-config "dev/config.edn"))
-                      (check-servers-up)
-                      (reset-wiremock)
-                      (f)))
+(use-fixtures :once test-util/fixture)
 
 (deftest report-generation
   (let [survey-id (System/currentTimeMillis)]
     (mock-gae survey-id)
-    (mock-mailjet)
+    (test-util/mock-mailjet)
     (test-util/try-for "Processing for too long" 20
                        (not= {"status" "OK", "message" "PROCESSING"}
                              (generate-report survey-id)))
@@ -198,12 +141,12 @@
       (is (= "OK" (get report-result "status")))
 
       (test-util/try-for "email not sent" 5
-                         (= 1 (email-sent-count (get report-result "file"))))
+                         (= 1 (test-util/email-sent-count (get report-result "file"))))
 
-      (is (= 200 (:status (http/get (str flow-services-url "/report/" (get report-result "file")))))))))
+      (is (= 200 (:status (test-util/get-report report-result)))))))
 
 (defn sentry-alerts-count []
-  (-> (http/post (str wiremock-url "/__admin/requests/count")
+  (-> (http/post (str test-util/wiremock-url "/__admin/requests/count")
                  {:as   :json
                   :body (json/generate-string
                           {"method"  "POST"
@@ -214,10 +157,10 @@
 (deftest sentry
   (let [survey-id (System/currentTimeMillis)
         current-errors (sentry-alerts-count)]
-    (http/post wiremock-mappings-url {:body (json/generate-string {"request"  {"method"          "GET"
-                                                                               "urlPath"         "/surveyrestapi"
-                                                                               "queryParameters" {"surveyId" {"equalTo" (str survey-id)}}}
-                                                                   "response" {"status" 500}})})
+    (http/post test-util/wiremock-mappings-url {:body (json/generate-string {"request"  {"method"          "GET"
+                                                                                         "urlPath"         "/surveyrestapi"
+                                                                                         "queryParameters" {"surveyId" {"equalTo" (str survey-id)}}}
+                                                                             "response" {"status" 500}})})
     (test-util/try-for "Processing for too long" 20
                        (= {"status" "ERROR", "message" "_error_generating_report"}
                           (generate-report survey-id)))

--- a/backend/test/akvo/flow_services/end_to_end_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_test.clj
@@ -178,6 +178,7 @@
   (test-util/wait-for-server "wiremock-proxy" 8080))
 
 (use-fixtures :once (fn [f]
+                      (core/config-logging (aero/read-config "dev/config.edn"))
                       (check-servers-up)
                       (reset-wiremock)
                       (f)))

--- a/backend/test/akvo/flow_services/geoshape_export_test.clj
+++ b/backend/test/akvo/flow_services/geoshape_export_test.clj
@@ -1,0 +1,102 @@
+(ns akvo.flow-services.geoshape-export-test
+  (:require [clojure.test :refer :all]
+            [akvo.flow-services.geoshape-export :as geoshape-export]
+            [testit.core :as it]
+            [cheshire.core :as json]))
+
+(def valid-polygon {:features [{:type       "Feature",
+                                :properties {:length "598909.00", :pointCount "3", :area "13872516944.93"},
+                                :geometry   {:type        "Polygon",
+                                             :coordinates [[[43.657240234315395 43.805380480517236]
+                                                            [44.38478909432889 42.843155681966564]
+                                                            [46.41390200704336 44.473117973161685]
+                                                            [43.657240234315395 43.805380480517236]]]}}],
+                    :type     "FeatureCollection"})
+
+(def line-coordinates [[43.657240234315395 43.805380480517236]])
+(def geo-question-id 2)
+(def questions [{:id 1 :text "question 1"}
+                {:id geo-question-id :text "geo question"}])
+
+(deftest export
+  (let [instance-id 3
+        responses [{:value       "one"
+                    :iteration   0
+                    :instance-id instance-id
+                    :question-id 1}
+                   {:value       (json/generate-string valid-polygon)
+                    :iteration   0
+                    :instance-id instance-id
+                    :question-id geo-question-id}]
+        instance-data [{:surveyalTime              16
+                        :collectionDate            #inst"2018-05-24T15:07:33.094-00:00"
+                        :surveyedLocaleIdentifier  "381t-1vk2-2ph7"
+                        :deviceIdentifier          "device"
+                        :surveyedLocaleDisplayName "vudhxhx"
+                        :submitterName             "a submitter"
+                        :surveyId                  58863002
+                        :keyId                     instance-id
+                        :surveyedLocaleId          56023002}]
+        export-result (geoshape-export/build-feature-collection "any"
+                                                                geo-question-id
+                                                                questions
+                                                                responses
+                                                                (constantly instance-data))]
+
+    (it/fact "generic properties"
+      export-result
+      =in=>
+      {:properties {:formId       "any"
+                    :questionId   2
+                    :questionText "geo question"}
+       :type       "FeatureCollection"})
+
+    (it/fact "contains the whole first feature of the response"
+      export-result
+      =in=>
+      {:features [{"geometry"   {"coordinates" [[[43.657240234315395 43.805380480517236]
+                                                 [44.38478909432889 42.843155681966564]
+                                                 [46.41390200704336 44.473117973161685]
+                                                 [43.657240234315395 43.805380480517236]]]
+                                 "type"        "Polygon"}
+                   "properties" {"area"       "13872516944.93"
+                                 "length"     "598909.00"
+                                 "pointCount" "3"}
+                   "type"       "Feature"}]})
+
+    (it/fact "it also contains other responses for the same instance-id"
+      export-result
+      =in=>
+      {:features [{"properties" {"question 1" "one"}}]})
+
+    (it/fact "and the instance data"
+      export-result
+      =in=>
+      {:features [{"properties" {"Duration"          "00:00:16"
+                                 "Submitter"         "a submitter"
+                                 "Submission Date"   "24-05-2018 15:07:33 UTC"
+                                 "Instance"          "3"
+                                 "Device identifier" "device"
+                                 "Display Name"      "vudhxhx"
+                                 "Identifier"        "381t-1vk2-2ph7"}}]})))
+
+
+(defn invalid [response-delta]
+  (let [responses [(-> (merge {:value       valid-polygon
+                               :iteration   0
+                               :instance-id 3
+                               :question-id geo-question-id}
+                              response-delta)
+                       (update :value json/generate-string))]
+        instance-data []]
+    (it/fact
+      (geoshape-export/build-feature-collection "any" geo-question-id questions responses (constantly instance-data))
+      =in=>
+      {:features empty?})))
+
+(deftest export-invalid-data
+
+  (invalid {:value (assoc-in valid-polygon [:features 0 :geometry :type] "Other than Polygon")})
+  (invalid {:value (assoc-in valid-polygon [:features 0 :geometry :coordinates 1] line-coordinates)})
+  (invalid {:question-id (inc geo-question-id)})
+  (invalid {:iteration 1}))

--- a/backend/test/akvo/flow_services/test_util.clj
+++ b/backend/test/akvo/flow_services/test_util.clj
@@ -1,5 +1,15 @@
 (ns akvo.flow-services.test-util
+  (:require [clj-http.client :as http]
+            [akvo.flow-services.core :as core]
+            [aero.core :as aero]
+            [cheshire.core :as json])
   (:import (java.net Socket)))
+
+(def wiremock-url "http://wiremock-proxy:8080")
+(def wiremock-mappings-url (str wiremock-url "/__admin/mappings"))
+(def flow-services-url "http://localhost:3000")
+(def gae-local {:hostname "localhost"
+                :port     8888})
 
 (defmacro try-for [msg how-long & body]
   `(let [start-time# (System/currentTimeMillis)]
@@ -21,3 +31,59 @@
            (with-open [_ (Socket. host (int port))]
              true)))
 
+(defn mock-mailjet []
+  (http/post wiremock-mappings-url {:body (json/generate-string {"request"  {"method"  "POST"
+                                                                             "urlPath" "/mailjet/send"}
+                                                                 "response" {"status" 200
+                                                                             "body"   "ok"}})}))
+
+(defn email-sent-count [body]
+  (-> (http/post (str wiremock-url "/__admin/requests/count")
+                 {:as   :json
+                  :body (json/generate-string
+                          {"method"       "POST"
+                           "bodyPatterns" [{"matches" (str ".*" body ".*")}]
+                           "urlPath"      "/mailjet/send"})})
+      :body
+      :count))
+
+(defn reset-wiremock []
+  (http/post (str wiremock-mappings-url "/reset")))
+
+(defn get-report [report-result]
+  (http/get (str flow-services-url "/report/" (get report-result "file"))))
+
+(defn setup-wiremock [messages]
+  (doseq [message messages]
+    (http/post wiremock-mappings-url {:body (json/generate-string message)})))
+
+(defn check-servers-up []
+  (wait-for-server "localhost" 3000)
+  (wait-for-server "localhost" 8888)
+  (wait-for-server "wiremock-proxy" 8080))
+
+(defn fixture [f]
+  (core/config-logging (aero/read-config "dev/config.edn"))
+  (check-servers-up)
+  (reset-wiremock)
+  (f))
+
+(defn instance-data [survey-id instance-id]
+  {"request"  {"method"          "GET"
+               "urlPath"         "/instancedata"
+               "queryParameters" {"action"           {"equalTo" "getInstanceData"}
+                                  "surveyInstanceId" {"equalTo" (str instance-id)}}}
+   "response" {"status"   200
+               "jsonBody" {"surveyInstanceData"   {"surveyedLocaleDisplayName" "a survey display name"
+                                                   "surveyId"                  survey-id
+                                                   "surveyedLocaleId"          147442028
+                                                   "userID"                    1
+                                                   "collectionDate"            1418598306000
+                                                   "submitterName"             "BASH & JAMES"
+                                                   "deviceIdentifier"          "IMPORTER"
+                                                   "surveyalTime"              0
+                                                   "surveyedLocaleIdentifier"  "a6ey-5r1h-6a0y"
+                                                   "keyId"                     instance-id}
+                           "latestApprovalStatus" ""
+                           "resultCount"          0
+                           "offset"               0}}})

--- a/doc/RunningLocally.md
+++ b/doc/RunningLocally.md
@@ -21,3 +21,8 @@ or the integration tests:
 ```sh
 docker-compose exec backend lein test :integration
 ```
+
+### Connecting to Flow services
+
+If you need to connect to a tenant, copy the configuration folder of the tentant from akvo-flow-server-config to `backend/dev/flow-server-config`. 
+Make sure that you do not commit it!

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,6 +9,7 @@ services:
 
   tests:
     image: akvo-flow-services-dev:develop
+    network_mode: service:mainnetwork
     volumes:
       - ./backend:/app
       - ~/.m2:/root/.m2


### PR DESCRIPTION
Fixes #193 

Parse the response value and extract a pipe delimited value as per
org.waterforpeople.mapping.dataexport.GraphicalSurveySummaryExporter.buildOptionString
and org.waterforpeople.mapping.dataexport.GraphicalSurveySummaryExporter.cascadeCellValues
in Flow, which are slightly different.

Done on top of #190. 