### PR TITLE
[#192] Return error when surveyId is null

### DIFF
--- a/backend/src/akvo/flow_services/core.clj
+++ b/backend/src/akvo/flow_services/core.clj
@@ -41,7 +41,8 @@
   (let [criteria (json/parse-string (:criteria params))] ; TODO: validation
     (response (scheduler/invalidate-cache criteria))))
 
-
+(defn- null? [x]
+  (or (nil? x) (= "null" x)))
 
 (defroutes ^:private endpoints
   (GET "/" [] "OK")
@@ -50,7 +51,8 @@
   (GET "/generate" [:as {params :params}]
     (let [criteria (json/parse-string (:criteria params))  ;; TODO: validation
           callback (:callback params)]
-      (if (or (nil? criteria) (= "null" criteria))
+      (if (or (null? criteria)
+              (null? (get criteria "surveyId")))
         {:status 400 :headers {} :body "Bad Request"}
         (generate-report criteria callback))))
 


### PR DESCRIPTION
Flow Dashboard is requesting a "null" surveyId for some reason.

This causes a NumberFormatException in Flow that is translated to a
500 error in flow-services, which causes an alert.

Fixes #192