### PR TITLE
Logging improvements

### DIFF
--- a/backend/src/akvo/flow_services/cascade.clj
+++ b/backend/src/akvo/flow_services/cascade.clj
@@ -31,7 +31,8 @@
             [clojure.string :as str]
             [aws.sdk.s3 :as s3]
             [taoensso.timbre :refer [errorf debugf infof]]
-            [akvo.flow-services.util :as util]))
+            [akvo.flow-services.util :as util]
+            [taoensso.timbre :as log]))
 
 ;; Each node is roughly ~1KB (depending on the code & name values)
 ;; We have a maximum of 1MB per request
@@ -422,7 +423,8 @@
     (or separator \,)))
 
 (jobs/defjob UploadCascadeJob [job-data]
-  (let [{:strs [uploadDomain cascadeResourceId numLevels uniqueIdentifier filename includeCodes]} (conversion/from-job-data job-data)
+  (let [{:strs [uploadDomain cascadeResourceId numLevels uniqueIdentifier filename includeCodes] :as data} (conversion/from-job-data job-data)
+        _ (log/info "Upload cascade job" data)
         levels (Long/parseLong numLevels)
         codes? (Boolean/valueOf includeCodes)
         base (format "%s/%s" (:base-path @config/settings) "uploads")

--- a/backend/src/akvo/flow_services/core.clj
+++ b/backend/src/akvo/flow_services/core.clj
@@ -129,7 +129,8 @@
 (defn config-logging [cfg]
   (timbre/handle-uncaught-jvm-exceptions!)
   (timbre/set-level! (log-level cfg))
-  (timbre/merge-config! {:timestamp-opts {:pattern "yyyy-MM-dd HH:mm:ss,SSS"}})
+  (timbre/merge-config! {:timestamp-opts {:pattern "yyyy-MM-dd HH:mm:ss,SSS"}
+                         :output-fn (partial timbre/default-output-fn {:stacktrace-fonts {}})})
   (when-let [akvo-log-level (:akvo-log-level cfg)]
     (when (timbre/level>= (log-level cfg) akvo-log-level)
       (timbre/set-level! akvo-log-level))
@@ -163,4 +164,5 @@
                {:join? false :port (:http-port cfg)})))
 
 (comment
-  (reset! config/settings (aero/read-config "dev/config.edn")))
+  (reset! config/settings (aero/read-config "dev/config.edn"))
+  (config-logging (aero/read-config "dev/config.edn")))

--- a/backend/src/akvo/flow_services/scheduler.clj
+++ b/backend/src/akvo/flow_services/scheduler.clj
@@ -17,7 +17,7 @@
   (:import [org.quartz ObjectAlreadyExistsException]
            java.io.File)
   (:require [clojure.string :as str]
-            [taoensso.timbre :refer (infof warnf)]
+            [taoensso.timbre :refer (infof warnf) :as log]
             [clojurewerkz.quartzite [conversion :as conversion]
              [jobs :as jobs]
              [scheduler :as scheduler]
@@ -145,7 +145,8 @@
   (do-export (conversion/from-job-data job-data)))
 
 (jobs/defjob BulkUploadJob [job-data]
-  (let [{:strs [baseURL uniqueIdentifier filename uploadDomain surveyId id]} (conversion/from-job-data job-data)]
+  (let [{:strs [baseURL uniqueIdentifier filename uploadDomain surveyId id] :as data} (conversion/from-job-data job-data)]
+    (log/info "Bulk upload job:" data)
     (bulk-upload baseURL uniqueIdentifier filename uploadDomain surveyId)
     (scheduler/delete-job (jobs/key id))))
 


### PR DESCRIPTION
Remove ascii colors from stacktraces as they mess Stackdriver
Logging the cascade and bulk upload params so we can debug which files are causing exceptions

Fixes #224