### PR TITLE
[#222] Validates node data before trying to insert into local db

### DIFF
--- a/backend/test/akvo/flow_services/cascade_test.clj
+++ b/backend/test/akvo/flow_services/cascade_test.clj
@@ -27,3 +27,18 @@
   (is (= ["Empty cascade node on line 2. Row: d, ,f"]
          (cascade/validate-csv cascade-with-empty-nodes 3 \,)))
   (is (not (empty? (cascade/validate-csv "no-such-file" 3 \,)))))
+
+(deftest test-validate-nodes
+  (let [nodes-1 [{:id 1 :code "code-1" :name "name 1" :parent 0}
+                 {:id 2 :code "code-2" :name "name 1" :parent 0}
+                 {:id 3 :code "code-3" :name "name 3" :parent 1}
+                 {:id 4 :code "code-4" :name "name 4" :parent 1}
+                 {:id 5 :code "code-5" :name " name 5" :parent 2}
+                 {:id 6 :code "code-6" :name "name 5  " :parent 2}]
+        nodes-2 [{:id 1 :code "code-1" :name "name 1" :parent 0}
+                 {:id 2 :code "code-2" :name "name 2" :parent 0}]
+        [result-1 msg] (cascade/validate-nodes-data nodes-1)
+        [result-2 _] (cascade/validate-nodes-data nodes-2)]
+    (is (= :error result-1))
+    (is (true? (.contains msg "Found duplicate name with same parent")))
+    (is (= :ok result-2))))


### PR DESCRIPTION
When we found a duplicate name for the same parent, we throw an
Exception that will be caught and notified to the GAE backend.
We're adding which nodes are the duplicates in the notification
to GAE