### PR TITLE
[#228] Enable full stack trace when logging

### DIFF
--- a/backend/prod/start-prod-env.sh
+++ b/backend/prod/start-prod-env.sh
@@ -21,4 +21,4 @@ if [ ! -d "/akvo-flow-server-config/" ]; then
     fi
 fi
 
-java -jar akvo-flow-services.jar /etc/config/akvo-flow-services/config.edn
+java -XX:-OmitStackTraceInFastThrow -jar akvo-flow-services.jar /etc/config/akvo-flow-services/config.edn


### PR DESCRIPTION
We're trying to avoid in the logs:
```
    Stack trace of root exception is empty;
    this is likely due to a JVM optimization that
    can be disabled with -XX:-OmitStackTraceInFastThrow
```