### PR TITLE
[#277] Use timbre's sentry appender to log/capture the Exception

### DIFF
--- a/backend/src/akvo/flow_services/error.clj
+++ b/backend/src/akvo/flow_services/error.clj
@@ -1,4 +1,5 @@
-(ns akvo.flow-services.error)
+(ns akvo.flow-services.error
+  (:require [taoensso.timbre :as log]))
 
 (defn fmap [v f-error f-ok]
   (if-let [error (get v ::error)]
@@ -25,7 +26,7 @@
   `(try
      ~body
      (catch Exception e#
-       (.printStackTrace e#)
+       (log/error e#)
        (error {:cause e#}))))
 
 (defn user-friendly-message [{:keys [::error]}]

--- a/backend/src/akvo/flow_services/error.clj
+++ b/backend/src/akvo/flow_services/error.clj
@@ -1,5 +1,4 @@
-(ns akvo.flow-services.error
-  (:require [taoensso.timbre :as log]))
+(ns akvo.flow-services.error)
 
 (defn fmap [v f-error f-ok]
   (if-let [error (get v ::error)]
@@ -26,7 +25,6 @@
   `(try
      ~body
      (catch Exception e#
-       (log/error e#)
        (error {:cause e#}))))
 
 (defn user-friendly-message [{:keys [::error]}]

--- a/backend/src/akvo/flow_services/scheduler.clj
+++ b/backend/src/akvo/flow_services/scheduler.clj
@@ -114,8 +114,9 @@
   (let [_ (notify-flow! job-data (create-report-in-flow job-data))
         report (e/wrap-exceptions (run-report job-data))]
     (notify-flow! job-data (finish-report-in-flow job-data report))
-    (when (e/ok? report)
-      (gdpr-email job-data))))
+    (e/fmap report
+            #(log/error (-> % ::e/error :cause))
+            (gdpr-email job-data))))
 
 (jobs/defjob ExportJob [job-data]
   (do-export (conversion/from-job-data job-data)))

--- a/backend/src/akvo/flow_services/scheduler.clj
+++ b/backend/src/akvo/flow_services/scheduler.clj
@@ -115,7 +115,7 @@
         report (e/wrap-exceptions (run-report job-data))]
     (notify-flow! job-data (finish-report-in-flow job-data report))
     (e/fmap report
-            #(log/error (-> % ::e/error :cause))
+            #(log/error %)
             (gdpr-email job-data))))
 
 (jobs/defjob ExportJob [job-data]

--- a/backend/test/akvo/flow_services/end_to_end_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_test.clj
@@ -203,6 +203,7 @@
     (mock-flow-report-api flow-report-id)
     (mock-gae survey-id)
     (test-util/mock-mailjet)
+    (test-util/mock-sentry)
     (test-util/try-for "Processing for too long" 20
                        (not= {"status" "OK", "message" "PROCESSING"}
                              (generate-report survey-id opts)))
@@ -223,6 +224,7 @@
         current-errors (sentry-alerts-count)]
     (invalidate-cache survey-id)
     (test-util/mock-flow-report-api)
+    (test-util/mock-sentry)
     (http/post test-util/wiremock-mappings-url {:body (json/generate-string {"request"  {"method"          "GET"
                                                                                          "urlPath"         "/surveyrestapi"
                                                                                          "queryParameters" {"surveyId" {"equalTo" (str survey-id)}}}

--- a/backend/test/akvo/flow_services/end_to_end_test.clj
+++ b/backend/test/akvo/flow_services/end_to_end_test.clj
@@ -217,13 +217,15 @@
 
       (is (= 200 (:status (test-util/get-report report-result))))
       (test-util/check-report-file-headers report-result "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-      (is (= ["IN_PROGRESS" "FINISHED_SUCCESS"] (final-report-state-in-flow flow-report-id))))))
+      (is (= ["IN_PROGRESS" "FINISHED_SUCCESS"] (final-report-state-in-flow flow-report-id)))
+      (is (zero? (sentry-alerts-count))))))
 
 (deftest error-in-report-generation
   (let [survey-id 43993002
         current-errors (sentry-alerts-count)]
     (invalidate-cache survey-id)
     (test-util/mock-flow-report-api)
+    (test-util/mock-mailjet)
     (test-util/mock-sentry)
     (http/post test-util/wiremock-mappings-url {:body (json/generate-string {"request"  {"method"          "GET"
                                                                                          "urlPath"         "/surveyrestapi"

--- a/backend/test/akvo/flow_services/test_util.clj
+++ b/backend/test/akvo/flow_services/test_util.clj
@@ -38,6 +38,11 @@
                                                                              "urlPath" "/mailjet/send"}
                                                                  "response" {"status" 200
                                                                              "body"   "ok"}})}))
+(defn mock-sentry []
+  (http/post wiremock-mappings-url {:body (json/generate-string {"request"  {"method"  "POST"
+                                                                             "urlPath" "/sentry/api/213123/store/"}
+                                                                 "response" {"status" 200
+                                                                             "body"   "ok"}})}))
 
 (defn mock-flow-report-api []
   (http/post wiremock-mappings-url


### PR DESCRIPTION
* Setup the sentry endpoint in wiremock to avoid a 'warning' in the
  logs when running the tests