### PR TITLE
Issue/290 presigned s3

### DIFF
--- a/backend/src/akvo/flow_services/aws_s3.clj
+++ b/backend/src/akvo/flow_services/aws_s3.clj
@@ -1,0 +1,31 @@
+(ns akvo.flow-services.aws-s3
+  (:require [akvo.commons.config :as config]
+            [akvo.flow-services.util :refer [hmac-sha256]]
+            [cheshire.core :as json])
+  (:import [java.text SimpleDateFormat]
+           [java.util Date]
+           [java.time Instant]))
+
+;; https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
+;; https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
+
+
+(defn signing-key
+  [key date region service]
+  (let [secret (str "AWS4" key)
+        date-key (hmac-sha256 secret date {})
+        region-key (hmac-sha256 date-key region {})
+        service-key (hmac-sha256 region-key service {})
+        signing (hmac-sha256 service-key "aws4_request" {})]
+    signing))
+
+(defn policy
+  [bucket]
+  (let [policy {:expiration (-> (Instant/now)
+                                (.plusSeconds 3600)
+                                (.toString))
+                :conditions [{"bucket" bucket}
+                             ["starts-with" "$key" "images/"]
+                             {"acl" "public-read"}
+                             {"success_action_status" "201"}]}]
+    (json/generate-string policy)))

--- a/backend/src/akvo/flow_services/aws_s3.clj
+++ b/backend/src/akvo/flow_services/aws_s3.clj
@@ -2,9 +2,11 @@
   (:require [akvo.commons.config :as config]
             [akvo.flow-services.util :refer [hmac-sha256]]
             [cheshire.core :as json])
-  (:import [java.text SimpleDateFormat]
-           [java.util Date]
-           [java.time Instant]))
+  (:import [java.text DateFormat]
+           [java.time Instant ZonedDateTime ZoneId]
+           [java.time.format DateTimeFormatter]
+           [java.util Base64 Date]
+           [org.apache.commons.codec.binary.Hex]))
 
 ;; https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 ;; https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
@@ -19,13 +21,95 @@
         signing (hmac-sha256 service-key "aws4_request" {})]
     signing))
 
+(defn utc-datetime
+  []
+  (ZonedDateTime/now (ZoneId/of "UTC")))
+
+(defn yyyyMMdd
+  [dt]
+  (.format (DateTimeFormatter/ofPattern "yyyyMMdd") dt))
+
+(defn iso8601-instant
+  [dt]
+  (.format (DateTimeFormatter/ISO_INSTANT) dt))
+
+(defn x-amz-date
+  "20200520T050551Z"
+  [dt]
+  (.format (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss'Z'") dt))
+
+(defn x-aws-credential
+  "<access-key-id>/<date-in-yyyyMMdd>/<region>/s3/aws4_request"
+  [access-key date region]
+  (format "%s/%s/%s/s3/aws4_request"
+          access-key
+          (yyyyMMdd date)
+          region))
+
 (defn policy
-  [bucket]
-  (let [policy {:expiration (-> (Instant/now)
-                                (.plusSeconds 3600)
-                                (.toString))
-                :conditions [{"bucket" bucket}
-                             ["starts-with" "$key" "images/"]
-                             {"acl" "public-read"}
-                             {"success_action_status" "201"}]}]
-    (json/generate-string policy)))
+  [bucket access-key region ttl-in-seconds acl conditions]
+  (let [date (utc-datetime)
+        x-credential (x-aws-credential access-key date region)
+        x-date (x-amz-date date)
+        base-conditions [{"bucket" bucket}
+                         {"acl" acl}
+                         {"success_action_status" "201"}
+                         {"x-amz-algorithm" "AWS4-HMAC-SHA256"}
+                         {"x-amz-credential" x-credential}
+                         {"x-amz-date" x-date}]
+        policy {:expiration (iso8601-instant (.plusSeconds date ttl-in-seconds))
+                :conditions (apply conj base-conditions conditions)}]
+    {:bucket bucket
+     :acl acl
+     :success_action_status "201"
+     :x-amz-algorithm "AWS4-HMAC-SHA256"
+     :x-amz-credential x-credential
+     :x-amz-date x-date
+     :policy policy}))
+
+(defn image-policy
+  [bucket access-key region ttl-in-seconds]
+  (policy bucket access-key region ttl-in-seconds "public-read" [["starts-with", "$key", "images/"]
+                                                                 ["starts-with", "$content-type", "image/"]]))
+(defn data-policy
+  [bucket access-key region ttl-in-seconds]
+  (policy bucket access-key region ttl-in-seconds "private" [["starts-with", "$key", "devicezip/"]
+                                                             ["eq", "$content-type", "application/zip"]]))
+(defn base64
+  [ba]
+  (.encodeToString (Base64/getEncoder) ba))
+
+(defn encode-policy
+  [policy]
+  (-> policy
+      (json/generate-string)
+      (.getBytes "UTF-8")
+      (base64)))
+
+(defn signature
+  [secret region policy]
+  (let [encoded (encode-policy policy)
+        sk (signing-key secret (yyyyMMdd (utc-datetime)) region "s3")
+        sig (hmac-sha256 sk encoded {})]
+    (Hex/encodeHexString sig)))
+
+
+(comment
+
+  (def uat1 (get @config/configs "akvoflow-uat1"))
+
+  (image-policy "akvoflow-uat1" (:access-key uat1) "eu-west-1" 3600)
+
+  (def fields
+    (let [bucket "akvoflow-uat1"
+          region "eu-west-1"
+          access-key (:access-key uat1)
+          policy (image-policy bucket access-key region 3600)
+          sig (signature (:secret-key uat1) region policy)]
+      (-> policy
+          (assoc :policy (encode-policy policy))
+          (assoc :x-amz-signature sig))))
+
+  (clojure.pprint/pprint fields)
+
+  )

--- a/backend/src/akvo/flow_services/aws_s3.clj
+++ b/backend/src/akvo/flow_services/aws_s3.clj
@@ -116,9 +116,9 @@
       (let [bucket (:s3bucket cfg)
             region "eu-west-1"
             access-key (:access-key cfg)
-            img-policy (image-policy bucket access-key region 3600) ;; TODO: short TTL
+            img-policy (image-policy bucket access-key region 90)
             img-sig (signature (:secret-key cfg) region (:policy img-policy))
-            zip-policy (data-policy bucket access-key region 3600) ;; TODO: short TTL
+            zip-policy (data-policy bucket access-key region 90)
             zip-sig (signature (:secret-key cfg) region (:policy zip-policy))]
         (-> {:image (-> img-policy
                         (assoc :policy (encode-policy (:policy img-policy)))

--- a/backend/src/akvo/flow_services/aws_s3.clj
+++ b/backend/src/akvo/flow_services/aws_s3.clj
@@ -6,7 +6,7 @@
            [java.time Instant ZonedDateTime ZoneId]
            [java.time.format DateTimeFormatter]
            [java.util Base64 Date]
-           [org.apache.commons.codec.binary.Hex]))
+           [org.apache.commons.codec.binary Hex]))
 
 ;; https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 ;; https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html

--- a/backend/src/akvo/flow_services/aws_s3.clj
+++ b/backend/src/akvo/flow_services/aws_s3.clj
@@ -117,14 +117,14 @@
             region "eu-west-1"
             access-key (:access-key cfg)
             img-policy (image-policy bucket access-key region 3600) ;; TODO: short TTL
-            img-sig (signature (:secret-key cfg) region img-policy)
+            img-sig (signature (:secret-key cfg) region (:policy img-policy))
             zip-policy (data-policy bucket access-key region 3600) ;; TODO: short TTL
-            zip-sig (signature (:secret-key cfg) region zip-policy)]
+            zip-sig (signature (:secret-key cfg) region (:policy zip-policy))]
         (-> {:image (-> img-policy
-                        (assoc :policy (encode-policy img-policy))
+                        (assoc :policy (encode-policy (:policy img-policy)))
                         (assoc :x-amz-signature img-sig))
              :zip (-> zip-policy
-                      (assoc :policy (encode-policy zip-policy))
+                      (assoc :policy (encode-policy (:policy zip-policy)))
                       (assoc :x-amz-signature zip-sig))}
             (json/generate-string)
             (resp/response)

--- a/backend/src/akvo/flow_services/core.clj
+++ b/backend/src/akvo/flow_services/core.clj
@@ -1,4 +1,4 @@
-;  Copyright (C) 2013-2014,2019 Stichting Akvo (Akvo Foundation)
+;  Copyright (C) 2013-2014,2019,2020 Stichting Akvo (Akvo Foundation)
 ;
 ;  This file is part of Akvo FLOW.
 ;
@@ -13,7 +13,7 @@
 ;  The full license text can also be seen at <http://www.gnu.org/licenses/agpl.html>.
 
 (ns akvo.flow-services.core
-  (:require [compojure.core :refer (defroutes GET POST OPTIONS routes)]
+  (:require [compojure.core :refer [defroutes GET POST OPTIONS routes]]
             [ring.util.response :refer (response charset content-type header)]
             [ring.adapter.jetty :refer (run-jetty)]
             [cheshire.core :as json]
@@ -25,7 +25,8 @@
              [uploader :as uploader]
              [cascade :as cascade]
              [stats :as stats]
-             [exporter :as exporter]]
+             [exporter :as exporter]
+             [aws-s3 :as s3]]
             [nrepl.server :as nrepl]
             [taoensso.timbre :as timbre]
             [taoensso.timbre.appenders.3rd-party.sentry :as sentry]
@@ -48,6 +49,9 @@
 (defroutes ^:private endpoints
   (GET "/" [] "OK")
   (GET "/healthz" [] "OK")
+
+  (GET "/sign" [:as {params :params}] ;; TODO: authentication!!!
+    (s3/handler params))
 
   (GET "/generate" [:as {params :params}]
     (let [criteria (json/parse-string (:criteria params))  ;; TODO: validation

--- a/backend/src/akvo/flow_services/core.clj
+++ b/backend/src/akvo/flow_services/core.clj
@@ -50,7 +50,7 @@
   (GET "/" [] "OK")
   (GET "/healthz" [] "OK")
 
-  (GET "/sign" [:as {params :params}] ;; TODO: authentication!!!
+  (GET "/sign" [:as {params :params}]
     (s3/handler params))
 
   (GET "/generate" [:as {params :params}]

--- a/backend/test/akvo/flow_services/aws_s3_test.clj
+++ b/backend/test/akvo/flow_services/aws_s3_test.clj
@@ -1,0 +1,26 @@
+(ns akvo.flow-services.aws-s3-test
+  (:require [akvo.flow-services.aws-s3 :refer :all]
+            [clojure.test :refer [deftest testing is]])
+  (:import [org.apache.commons.codec.binary Hex]))
+
+(deftest signing-key-test
+  (testing "Generating a signing key and comparing with docs"
+
+    ;; https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
+    ;;
+    ;; key = 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY'
+    ;; dateStamp = '20120215'
+    ;; regionName = 'us-east-1'
+    ;; serviceName = 'iam'
+    ;;
+    ;; kSecret  = '41575334774a616c725855746e46454d492f4b374d44454e472b62507852666943594558414d504c454b4559'
+    ;; kDate    = '969fbb94feb542b71ede6f87fe4d5fa29c789342b0f407474670f0c2489e0a0d'
+    ;; kRegion  = '69daa0209cd9c5ff5c8ced464a696fd4252e981430b10e3d3fd8e2f197d7a70c'
+    ;; kService = 'f72cfd46f26bc4643f06a11eabb6c0ba18780c19a8da0c31ace671265e3c87fa'
+    ;; kSigning = 'f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d'
+
+    (is (= (Hex/encodeHexString (signing-key "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+                                             "20120215"
+                                             "us-east-1"
+                                             "iam"))
+           "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"))))

--- a/backend/test/akvo/flow_services/util_test.clj
+++ b/backend/test/akvo/flow_services/util_test.clj
@@ -3,8 +3,11 @@
             [clojure.test :refer [deftest is testing]]))
 
 ;;
-(deftest hmac-sha1-test
+(deftest hmac-sha-test
   (testing "Base64 encoded HMAC-SHA1"
     ;; echo -n "value" | openssl dgst -binary -sha1 -hmac "key" | openssl base64 -A
     (is (= "V0Q6TAUjUKRGOINdZP1mgi+BMxk="
-           (hmac-sha1 "key" "value")))))
+           (hmac-sha1 "key" "value")))
+    ;; echo -n "value" | openssl dgst -binary -sha256 -hmac "key" | openssl base64 -A
+    (is (= "kPv88V50o2uJ29sqch2a7P/f3dxcg+J/dZJZT3GTJIE="
+           (hmac-sha256 "key" "value")))))

--- a/backend/test/akvo/flow_services/util_test.clj
+++ b/backend/test/akvo/flow_services/util_test.clj
@@ -1,0 +1,10 @@
+(ns akvo.flow-services.util-test
+  (:require [akvo.flow-services.util :refer :all]
+            [clojure.test :refer [deftest is testing]]))
+
+;;
+(deftest hmac-sha1-test
+  (testing "Base64 encoded HMAC-SHA1"
+    ;; echo -n "value" | openssl dgst -binary -sha1 -hmac "key" | openssl base64 -A
+    (is (= "V0Q6TAUjUKRGOINdZP1mgi+BMxk="
+           (hmac-sha1 "key" "value")))))

--- a/ci/akvo-flow-services.yaml.template
+++ b/ci/akvo-flow-services.yaml.template
@@ -60,6 +60,21 @@ spec:
           persistentVolumeClaim:
              claimName: akvo-flow-services-reports
       containers:
+      - name: akvo-flow-services-proxy
+        image: eu.gcr.io/akvo-lumen/akvo-flow-services-proxy:$TRAVIS_COMMIT
+        ports:
+        - containerPort: 8082
+        env:
+        - name: OIDC_DISCOVERY_URL
+          valueFrom:
+            configMapKeyRef:
+              name: flow-api
+              key: oidc.discovery.url
+        - name: OIDC_EXPECTED_ISSUER
+          valueFrom:
+            configMapKeyRef:
+              name: flow-api
+              key: oidc.expected.issuer
       - name: akvo-flow-services
         image: eu.gcr.io/akvo-lumen/akvo-flow-services:$TRAVIS_COMMIT
         ports:
@@ -133,8 +148,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - port: 3000
-    targetPort: 3000
+  - port: 8082
+    targetPort: 8082
   selector:
     run: akvo-flow-services
 ---

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -20,8 +20,35 @@ log Running backend test and uberjar
 docker run -v "${HOME}/.m2:/root/.m2" -v "$(pwd)/backend:/app" akvo-flow-services-dev:develop lein 'do' test, uberjar
 
 log Building production container
-docker build --rm=false -t "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services:${TRAVIS_COMMIT}" ./backend
-docker tag "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services:${TRAVIS_COMMIT}" "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services:develop"
+docker build --rm=false \
+       -t "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services:${TRAVIS_COMMIT}" \
+       -t "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services:develop" \
+       -t "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services:latest" \
+       ./backend
+
+log Building proxy and checking container
+(
+    cd nginx
+    docker build \
+	   -t "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services-proxy:latest" \
+	   -t "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services-proxy:${TRAVIS_COMMIT}" .
+
+    docker run \
+	   --rm \
+	   --entrypoint /usr/local/openresty/bin/openresty \
+	   "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services-proxy" \
+	   -t -c /usr/local/openresty/nginx/conf/nginx.conf
+
+    docker run \
+	   --rm \
+	   --entrypoint /usr/local/openresty/bin/openresty \
+	   "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services-proxy" \
+	   -t -c /usr/local/openresty/nginx/conf/nginx-test.conf
+
+    docker-compose up -d
+    docker-compose exec testnetwork /bin/sh -c 'cd /usr/local/src/ && ./entrypoint.sh ./test-auth.sh'
+    docker-compose down -v
+)
 
 log Starting docker compose env
 docker-compose -p akvo-flow-ci -f docker-compose.yml -f docker-compose.ci.yml up -d --build

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -46,7 +46,8 @@ else
     POD_MEM_REQUESTS="1024Mi"
     POD_MEM_LIMITS="2048Mi"
     log Pushing images
-    gcloud docker -- push eu.gcr.io/${PROJECT_NAME}/akvo-flow-services
+    gcloud docker -- push "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services:${TRAVIS_COMMIT}"
+    gcloud docker -- push "eu.gcr.io/${PROJECT_NAME}/akvo-flow-services-proxy:${TRAVIS_COMMIT}"
 fi
 
 log Deploying

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,16 @@
+FROM openresty/openresty:1.15.8.2-7-alpine-fat-nosse42
+
+RUN apk add --no-cache \
+    build-base~=0.5 \
+    openssl-dev~=1 \
+    git~=2 && \
+    luarocks install lua-resty-openidc 1.7.2-1 && \
+    cp /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.pem && \
+    mkdir -p /data/nginx/cache
+
+EXPOSE 8082
+
+COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY nginx-test.conf /usr/local/openresty/nginx/conf/nginx-test.conf
+
+ENTRYPOINT ["/usr/local/openresty/bin/openresty", "-c", "/usr/local/openresty/nginx/conf/nginx.conf", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
 
 EXPOSE 8082
 
+COPY authnz.lua /usr/local/openresty/nginx/conf/authnz.lua
 COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 COPY nginx-test.conf /usr/local/openresty/nginx/conf/nginx-test.conf
 

--- a/nginx/api.sh
+++ b/nginx/api.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu
+
+token=$(curl --silent \
+	     --data "client_id=0C1NQcW6mMWyvvOOZ6Dd5P6hJrjSbwPL" \
+	     --data "username=${AUTH0_USER}" \
+	     --data "password=${AUTH0_PASSWORD}" \
+	     --data "grant_type=password" \
+	     --data "scope=openid email" \
+	     --url "https://akvotest.eu.auth0.com/oauth/token" \
+	    | jq -M -r .id_token)
+
+
+URL="${1}"
+shift
+
+curl --silent \
+     --header "Authorization: Bearer ${token}" \
+     --request GET \
+     "$@" \
+     --url "${URL}" | jq -M .

--- a/nginx/authnz.lua
+++ b/nginx/authnz.lua
@@ -1,0 +1,60 @@
+local cjson = require("cjson")
+local openidc = require("resty.openidc")
+
+local function is_empty (s)
+   return string.len(string.gsub(s, "%s+", "")) == 0
+end
+
+local authorization = ngx.var.http_authorization
+
+if not authorization or is_empty(authorization) then
+   ngx.status = 401
+   local error = cjson.encode({error="Authentication required"})
+   ngx.say(error)
+   ngx.exit(ngx.HTTP_UNAUTHORIZED)
+end
+
+local opts = {
+   discovery = os.getenv("OIDC_DISCOVERY_URL"),
+   token_signing_alg_values_expected = { "RS256" },
+   accept_none_alg = false,
+   accept_unsupported_alg = false,
+   ssl_verify = "yes",
+   expiry_claim = "exp"
+}
+
+local validators = require "resty.jwt-validators"
+validators.set_system_leeway(120)
+
+local claims = {
+   exp = validators.is_not_expired(),
+   nbf = validators.opt_is_not_before(),
+   iss = validators.equals(os.getenv("OIDC_EXPECTED_ISSUER"))
+}
+
+local res, err, access_token = openidc.bearer_jwt_verify(opts, claims)
+if err or not res then
+   ngx.status = 403
+   if err then
+      local error = cjson.encode({error=err})
+      ngx.say(err)
+   else
+      local error = cjson.encode({error="Invalid access_token"})
+      ngx.say(error)
+   end
+   ngx.exit(ngx.HTTP_FORBIDDEN)
+end
+
+if res.email then
+   if res["https://akvo.org/app_metadata"] and res["https://akvo.org/app_metadata"]["akvo-flow-services-sign"]  then
+      ngx.req.set_header("X-Akvo-Email", res.email)
+      ngx.var.akvoemail = res.email
+   else
+      ngx.log(ngx.ERR, "Authorization required for user " .. res.email)
+      ngx.say(cjson.encode({error="Invalid access_token"}))
+      ngx.exit(ngx.HTTP_FORBIDDEN)
+   end
+else
+   ngx.say(cjson.encode({error="Invalid access_token"}))
+   ngx.exit(ngx.HTTP_FORBIDDEN)
+end

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+
+services:
+  testnetwork:
+    image: alpine:3.10
+    command: ["tail", "-f", "/dev/null"]
+    ports:
+      - 8082:8082
+    volumes:
+      - ./:/usr/local/src:ro
+    environment:
+      - AUTH0_USER
+      - AUTH0_PASSWORD
+  nginx:
+    image: eu.gcr.io/${PROJECT_NAME}/akvo-flow-services-proxy:latest
+    network_mode: service:testnetwork
+    environment:
+      - FLOW_SERVICES_BACKEND_URL=http://localhost:3000
+      - OIDC_DISCOVERY_URL=https://akvotest.eu.auth0.com/.well-known/openid-configuration
+      - OIDC_EXPECTED_ISSUER=https://akvotest.eu.auth0.com/
+  upstream:
+    image: eu.gcr.io/${PROJECT_NAME}/akvo-flow-services-proxy:latest
+    network_mode: service:testnetwork
+    entrypoint: ["/usr/local/openresty/bin/openresty", "-c", "/usr/local/src/nginx-test.conf", "-g", "daemon off;"]
+    volumes:
+      - ./:/usr/local/src:ro

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -eu
+
+apk add --no-cache \
+    wait4ports~=0.2 \
+    bash~=5 \
+    curl~=7 \
+    jq~=1.6
+
+exec "$@"

--- a/nginx/nginx-test.conf
+++ b/nginx/nginx-test.conf
@@ -1,0 +1,28 @@
+worker_processes 1;
+error_log logs/error.log;
+
+events {
+  worker_connections 128;
+}
+
+http {
+
+  server_tokens off;
+
+  server {
+
+    listen 3000;
+
+    location /invalidate {
+      return 200 'OK';
+    }
+
+    location /sign {
+      return 200 '{}';
+    }
+
+    location / {
+      return 200 'OK';
+    }
+  }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,167 @@
+env FLOW_SERVICES_BACKEND_URL;
+env OIDC_DISCOVERY_URL;
+env OIDC_EXPECTED_ISSUER;
+
+events {
+  worker_connections 128;
+}
+
+http {
+
+  server_tokens off;
+  lua_package_path '~/lua/?.lua;;';
+
+  resolver 8.8.8.8;
+  error_log stderr info;
+
+  log_format apm '"$time_local" client=$remote_addr '
+           'method=$request_method request="$request" '
+           'request_length=$request_length '
+           'status=$status bytes_sent=$bytes_sent '
+           'body_bytes_sent=$body_bytes_sent '
+           'referer=$http_referer '
+           'user_agent="$http_user_agent" '
+           'upstream_addr=$upstream_addr '
+           'upstream_status=$upstream_status '
+           'request_time=$request_time '
+           'upstream_response_time=$upstream_response_time '
+           'upstream_connect_time=$upstream_connect_time '
+           'upstream_header_time=$upstream_header_time';
+
+  # cache for discovery metadata documents
+  lua_shared_dict discovery 1m;
+  lua_shared_dict jwks 1m;
+  lua_shared_dict userinfo 20m;
+  lua_capture_error_log 32m;
+
+  lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.pem;
+
+  init_by_lua_block {
+        local errlog = require "ngx.errlog"
+        local status, err = errlog.set_filter_level(ngx.WARN)
+        if not status then
+            ngx.log(ngx.ERR, err)
+            return
+        end
+        ngx.log(ngx.WARN, "set error filter level: WARN")
+  }
+
+
+  server {
+
+    listen 8082;
+    gzip            on;
+    gzip_min_length 1000;
+    gzip_proxied    expired no-cache no-store private auth;
+    gzip_comp_level 9;
+    gzip_types      application/json;
+
+    large_client_header_buffers 16 32k;
+
+    access_log /usr/local/openresty/nginx/logs/access.log apm;
+
+
+    if ($http_x_forwarded_proto = "http") {
+      return 301 https://$host$request_uri;
+    }
+
+    location /sign {
+
+      default_type application/json;
+
+      more_set_headers 'Access-Control-Allow-Origin: *';
+      more_set_headers 'Access-Control-Allow-Credentials: true';
+      more_set_headers 'Access-Control-Allow-Methods: GET, OPTIONS';
+      more_set_headers 'Access-Control-Allow-Headers: Accept,Accept-Encoding,Accept-Language,Authorization,Connection,DNT,Host,Origin,Referer,User-Agent';
+
+      if ($request_method = 'OPTIONS') {
+        more_set_headers 'Content-Length: 0' 'Content-Type: text/plain' 'Access-Control-Max-Age: 1728000';
+        return 204;
+      }
+
+      set_by_lua $upstream 'return os.getenv("FLOW_SERVICES_BACKEND_URL")';
+      lua_ssl_verify_depth 2;
+      lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.pem;
+
+      set $akvoemail "";
+
+      access_by_lua_block {
+
+          local cjson = require("cjson")
+          local openidc = require("resty.openidc")
+
+          local function is_empty (s)
+            return string.len(string.gsub(s, "%s+", "")) == 0
+          end
+
+         local authorization = ngx.var.http_authorization
+
+         if not authorization or is_empty(authorization) then
+           ngx.status = 401
+           local error = cjson.encode({error="Authentication required"})
+           ngx.say(error)
+           ngx.exit(ngx.HTTP_UNAUTHORIZED)
+         end
+
+         local opts = {
+            discovery = os.getenv("OIDC_DISCOVERY_URL"),
+            token_signing_alg_values_expected = { "RS256" },
+            accept_none_alg = false,
+            accept_unsupported_alg = false,
+            ssl_verify = "yes",
+            expiry_claim = "exp"
+         }
+
+         local validators = require "resty.jwt-validators"
+         validators.set_system_leeway(120)
+         local res, err, access_token = openidc.bearer_jwt_verify(opts,
+            {
+              exp = validators.is_not_expired(),
+              nbf = validators.opt_is_not_before(),
+              iss = validators.equals(os.getenv("OIDC_EXPECTED_ISSUER"))
+            })
+
+         if err or not res then
+            ngx.status = 403
+            if err then
+              local error = cjson.encode({error=err})
+              ngx.say(err)
+            else
+              local error = cjson.encode({error="Invalid access_token"})
+              ngx.say(error)
+            end
+            ngx.exit(ngx.HTTP_FORBIDDEN)
+         end
+
+         if res.email then
+           if res["https://akvo.org/app_metadata"] and res["https://akvo.org/app_metadata"]["akvo-flow-services-sign"]  then
+	     ngx.req.set_header("X-Akvo-Email", res.email)
+             ngx.var.akvoemail = res.email
+	   else
+	     ngx.log(ngx.ERR, "Authorization required for user " .. res.email)
+	     ngx.say(cjson.encode({error="Invalid access_token"}))
+             ngx.exit(ngx.HTTP_FORBIDDEN)
+	   end
+         else
+           ngx.say(cjson.encode({error="Invalid access_token"}))
+           ngx.exit(ngx.HTTP_FORBIDDEN)
+	 end
+      }
+
+      proxy_pass http://localhost:3000;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+      set_by_lua $upstream 'return os.getenv("FLOW_API_BACKEND_URL")';
+      proxy_pass http://localhost:3000;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+  }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,3 @@
-env FLOW_SERVICES_BACKEND_URL;
 env OIDC_DISCOVERY_URL;
 env OIDC_EXPECTED_ISSUER;
 
@@ -79,74 +78,12 @@ http {
         return 204;
       }
 
-      set_by_lua $upstream 'return os.getenv("FLOW_SERVICES_BACKEND_URL")';
       lua_ssl_verify_depth 2;
       lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.pem;
 
       set $akvoemail "";
 
-      access_by_lua_block {
-
-          local cjson = require("cjson")
-          local openidc = require("resty.openidc")
-
-          local function is_empty (s)
-            return string.len(string.gsub(s, "%s+", "")) == 0
-          end
-
-         local authorization = ngx.var.http_authorization
-
-         if not authorization or is_empty(authorization) then
-           ngx.status = 401
-           local error = cjson.encode({error="Authentication required"})
-           ngx.say(error)
-           ngx.exit(ngx.HTTP_UNAUTHORIZED)
-         end
-
-         local opts = {
-            discovery = os.getenv("OIDC_DISCOVERY_URL"),
-            token_signing_alg_values_expected = { "RS256" },
-            accept_none_alg = false,
-            accept_unsupported_alg = false,
-            ssl_verify = "yes",
-            expiry_claim = "exp"
-         }
-
-         local validators = require "resty.jwt-validators"
-         validators.set_system_leeway(120)
-         local res, err, access_token = openidc.bearer_jwt_verify(opts,
-            {
-              exp = validators.is_not_expired(),
-              nbf = validators.opt_is_not_before(),
-              iss = validators.equals(os.getenv("OIDC_EXPECTED_ISSUER"))
-            })
-
-         if err or not res then
-            ngx.status = 403
-            if err then
-              local error = cjson.encode({error=err})
-              ngx.say(err)
-            else
-              local error = cjson.encode({error="Invalid access_token"})
-              ngx.say(error)
-            end
-            ngx.exit(ngx.HTTP_FORBIDDEN)
-         end
-
-         if res.email then
-           if res["https://akvo.org/app_metadata"] and res["https://akvo.org/app_metadata"]["akvo-flow-services-sign"]  then
-	     ngx.req.set_header("X-Akvo-Email", res.email)
-             ngx.var.akvoemail = res.email
-	   else
-	     ngx.log(ngx.ERR, "Authorization required for user " .. res.email)
-	     ngx.say(cjson.encode({error="Invalid access_token"}))
-             ngx.exit(ngx.HTTP_FORBIDDEN)
-	   end
-         else
-           ngx.say(cjson.encode({error="Invalid access_token"}))
-           ngx.exit(ngx.HTTP_FORBIDDEN)
-	 end
-      }
+      access_by_lua_file /usr/local/openresty/nginx/conf/authnz.lua;
 
       proxy_pass http://localhost:3000;
       proxy_set_header Host $host;
@@ -156,7 +93,6 @@ http {
     }
 
     location / {
-      set_by_lua $upstream 'return os.getenv("FLOW_API_BACKEND_URL")';
       proxy_pass http://localhost:3000;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/test-auth.sh
+++ b/nginx/test-auth.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eu
+
+wait4ports nginx=tcp://localhost:8082 upstream=tcp://localhost:3000
+
+curl --silent --request GET --url "http://localhost:8082/" | grep 'OK'
+curl --silent --request GET --url "http://localhost:8082/invalidate" | grep 'OK'
+curl --verbose "http://localhost:8082/sign?instance=akvoflow-uat1" 2>&1 | grep 'HTTP.*401'
+./api.sh "http://localhost:8082/sign?instance=akvoflow-uat1" | grep '{}'


### PR DESCRIPTION
* We have a new `/sign` endpoint to produce policy and data useful for `POST` requests to AWS S3
* There is [s3-beam](https://github.com/martinklepsch/s3-beam) but it doesn't support V4 of signatures yet. - https://github.com/martinklepsch/s3-beam/issues/38#issuecomment-534363066
  * The Java AWS SDK doesn't have the `createSignedPost` method that other languages have
* We had the manually implement all the AWS V4 signatures

Notes:
- We want to merge **after** we implement authentication for the endpoint `/sign`
  - Instead of adding it to Clojure code, we're going to follow the [openresty](https://github.com/akvo/akvo-flow-api/tree/develop/nginx-auth0) approach of `akvo-flow-api`