### PR TITLE
[#302] Send sentry exception in case of errors config

### DIFF
--- a/backend/project.clj
+++ b/backend/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/data.csv "0.1.3"]
                  [nrepl/nrepl "0.6.0"]
-                 [org.akvo/commons "0.4.6" :exclusions [me.raynes/fs
+                 [org.akvo/commons "0.4.8" :exclusions [me.raynes/fs
                                                         org.clojure/tools.nrepl]]
                  [com.taoensso/timbre "4.10.0"]
                  [timbre-ns-pattern-level "0.1.2"]

--- a/backend/src/akvo/flow_services/core.clj
+++ b/backend/src/akvo/flow_services/core.clj
@@ -164,6 +164,9 @@
   (when-let [cfg (reset! config/settings (aero/read-config config-file))]
     (config-logging cfg)
     (config/reload (:config-folder cfg))
+    (when-let [errors-config (seq @config/errors-config)]
+      (doseq [error-config errors-config]
+        (timbre/log :error "Config error" error-config)))
     (init)
     (stats/schedule-stats-job (:stats-schedule-time cfg))
     (reset! system {:nrepl (nrepl/start-server :port 7888 :bind (:nrepl-bind cfg "localhost"))


### PR DESCRIPTION
Using `timbre/log :error ` with current sentry appender sends a sentry notification
Eg: https://sentry.io/organizations/akvo-foundation/issues/2231569559/?project=1187876&query=is%3Aunresolved

- [x] Depends on https://github.com/akvo/akvo-commons/tree/issue-34
- [x] it will need to update dependency version on project.clj