### PR TITLE
[#319] Increase storage size

### DIFF
--- a/ci/akvo-flow-services.yaml.template
+++ b/ci/akvo-flow-services.yaml.template
@@ -164,4 +164,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 150Gi
+      storage: 200Gi


### PR DESCRIPTION
A stopgap solution to running out space on the reports and uploads drive

After merging this, you might have to restart the pod manually to trigger the volume expansion.
@muloem  already took care of making the K8s storage class allow volume expansion.

**References:**

 - https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/volume-expansion
 - https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/#file-system-expansion

